### PR TITLE
Build and release actions

### DIFF
--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -14,7 +14,7 @@ jobs:
           operator-sdk-version: v0.11.0
 
       - name: "Formatting check"
-        run: make test/check
+        run: make code/check
 
       - name: "Compile"
         run: make code/compile

--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -10,5 +10,11 @@ jobs:
         with:
           operator-sdk-version: v0.11.0
 
-      - name: "basic checks"
-        run: make test/ci
+      - name: "Formatting check"
+        run: make test/check
+
+      - name: "Compile"
+        run: make code/compile
+
+      - name: "Test"
+        run: make test/unit

--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.3'
       - uses: jpkrohling/setup-operator-sdk@v1-release
         with:
           operator-sdk-version: v0.11.0

--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -1,0 +1,14 @@
+name: "CI Workflow"
+on: [push, pull_request]
+
+jobs:
+  basic-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: jpkrohling/setup-operator-sdk@v1-release
+        with:
+          operator-sdk-version: v0.11.0
+
+      - name: "basic checks"
+        run: make test/ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "CI Workflow"
+name: "CI"
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,11 @@
-name: "Release Docker image"
+name: "Release"
 on:
   push:
     tags:
       - 'v*'
 
 jobs:
-  release-docker:
+  docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10}) # extracts the tag name from refs/tags/v1.2.3
 
       - name: "Build image"
-        run: make image/build
+        run: make image/build TAG=$RELEASE_VERSION
 
       - name: "Docker login to Quay.io"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: "CI Workflow"
+name: "Release Docker image"
 on:
   push:
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: "CI Workflow"
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  basic-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.3'
+      - uses: jpkrohling/setup-operator-sdk@v1-release
+        with:
+          operator-sdk-version: v0.11.0
+
+      - name: Set tag in environment
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10}) # extracts the tag name from refs/tags/v1.2.3
+
+      - name: "Build image"
+        run: make image/build
+
+      - name: "Docker login to Quay.io"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD quay.io
+
+      - name: "Push image"
+        run: make image/push TAG=$RELEASE_VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - 'v*'
 
 jobs:
-  basic-checks:
+  release-docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+PROJECT=postgresql-controller
+ORG?=lunarway
+REG?=quay.io
+TAG?=latest
+NAMESPACE=default
+SHELL=/bin/bash
+COMPILE_TARGET=./build/_output/bin/$(PROJECT)
+GOOS=darwin
+GOARCH=amd64
+
+.PHONY: code/run
+code/run:
+	@operator-sdk up local --namespace=${NAMESPACE}
+
+.PHONY: code/compile
+code/compile:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -o=$(COMPILE_TARGET) ./cmd/manager
+
+.PHONY: code/check
+code/check:
+	@diff -u <(echo -n) <(gofmt -d `find . -type f -name '*.go' -not -path "./vendor/*"`)
+
+.PHONY: code/fix
+code/fix:
+	@gofmt -w `find . -type f -name '*.go' -not -path "./vendor/*"`
+
+.PHONY: image/build
+image/build: code/compile
+	@operator-sdk build ${REG}/${ORG}/${PROJECT}:${TAG}
+
+.PHONY: image/push
+image/push:
+	docker push ${REG}/${ORG}/${PROJECT}:${TAG}
+
+.PHONY: image/build/push
+image/build/push: image/build image/push
+
+.PHONY: test/unit
+test/unit:
+	@echo Running tests:
+	go test -v -race -cover ./pkg/...
+
+.PHONY: test/ci
+test/ci: code/compile code/check test/unit

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,11 @@ image/build/push: image/build image/push
 test/unit:
 	@echo Running tests:
 	go test -v -race -cover ./pkg/...
+
+.PHONY: release
+release:
+	sed -i "" 's|REPLACE_IMAGE|${REG}/${ORG}/${PROJECT}:${TAG}|g' deploy/operator.yaml
+	git add deploy/operator.yaml
+	git commit -m"Release ${TAG}"
+	git tag ${TAG}
+	git push --tags

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,3 @@ image/build/push: image/build image/push
 test/unit:
 	@echo Running tests:
 	go test -v -race -cover ./pkg/...
-
-.PHONY: test/ci
-test/ci: code/compile code/check test/unit

--- a/README.md
+++ b/README.md
@@ -1,33 +1,5 @@
 # PostgreSQL controller
 
-This is a Kubernetes controller for managing users and their access rights to a PostgreSQL database instance.
-Its purpose is to make a codified description of what users have access to what databases and for what reason along with providing an auditable log of changes.
-
-# Design
-
-The controller defines a Kubernetes [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) called `PostgreSQLUser`.  
-It contains metadata about the user along with its access rights to databases.
-
-This is an example of a user `bso` that has the role `iam_developer` and write access to the `user` database between 10 AM to 2 PM on september 9th.
-
-```yaml
-apiVersion: lunar.bank/v1beta1
-kind: PostgreSQLUser
-metadata:
-  name: bso
-  namespace: dev
-spec:
-  role: iam_developer
-  reason: "I am a developer"
-  write:
-  - database: user
-    reason: "Related to support ticket LW-1234"
-    start: 2019-09-16T10:00:00Z
-    end: 2019-09-16T14:00:00Z
-```
-
-Users are created with the `rds_iam` role allowing them to sign in with a short lived password issued from AWS.
-
 # Development
 
 This project uses the [Operator SDK framework](https://github.com/operator-framework/operator-sdk) and its associated CLI.  

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Users are created with the `rds_iam` role allowing them to sign in with a short 
 
 This project uses the [Operator SDK framework](https://github.com/operator-framework/operator-sdk) and its associated CLI.  
 Follow the [offical installation instructions](https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md) to get started.
+
+# Releasing
+
+To release a new version of the operator run `make release TAG=vx.x.x`.
+This will ensure to update `deploy/operator.yaml` with the version, create a commit and push it.
+The `Release` GitHub Action workflow is then triggered and pushes the Docker image to quay.io.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # PostgreSQL controller
 
+This is a Kubernetes controller for managing users and their access rights to a PostgreSQL database instance.
+Its purpose is to make a codified description of what users have access to what databases and for what reason along with providing an auditable log of changes.
+
+# Design
+
+The controller defines a Kubernetes [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) called `PostgreSQLUser`.  
+It contains metadata about the user along with its access rights to databases.
+
+This is an example of a user `bso` that has the role `iam_developer` and write access to the `user` database between 10 AM to 2 PM on september 9th.
+
+```yaml
+apiVersion: lunar.bank/v1beta1
+kind: PostgreSQLUser
+metadata:
+  name: bso
+  namespace: dev
+spec:
+  role: iam_developer
+  reason: "I am a developer"
+  write:
+  - database: user
+    reason: "Related to support ticket LW-1234"
+    start: 2019-09-16T10:00:00Z
+    end: 2019-09-16T14:00:00Z
+```
+
+Users are created with the `rds_iam` role allowing them to sign in with a short lived password issued from AWS.
+
 # Development
 
 This project uses the [Operator SDK framework](https://github.com/operator-framework/operator-sdk) and its associated CLI.  

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,6 @@ spec:
       serviceAccountName: postgresql-controller
       containers:
         - name: postgresql-controller
-          # Replace this with the built image name
           image: quay.io/lunarway/postgresql-controller:v0.0.1-beta4
           command:
           - postgresql-controller

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: postgresql-controller
           # Replace this with the built image name
-          image: REPLACE_IMAGE
+          image: quay.io/lunarway/postgresql-controller:v0.0.1-beta4
           command:
           - postgresql-controller
           imagePullPolicy: Always


### PR DESCRIPTION
This change adds two GitHub Action workflows for building, testing and releasing the controller.
The `CI` workflow is triggered on all pushes and the `Release` flow is only triggered on new Git tag pushes. Use the `release` make target to create these tags, as this will create a new commit and update the `deploy/operator.yaml` specification.

Further some common targets are added to a `Makefile` to ease development.