### PR TITLE
Document the design

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ metadata:
   name: user
 spec:
   name: user
+  password:
+    value: <strong-password>
   host:
     value: some.host.com
 ```
 
-The `host` field is modelled like Kubernetes core's [`EnvVarSource`](https://github.com/kubernetes/api/blob/665c8a257c1af277521b08dd43d5c73570405ef0/core/v1/types.go#L1847-L1862), so it can specify raw values like above or reference ConfigMaps etc.
+The `password` and `host` fields are modelled like Kubernetes core's [`EnvVarSource`](https://github.com/kubernetes/api/blob/665c8a257c1af277521b08dd43d5c73570405ef0/core/v1/types.go#L1847-L1862), so it can specify raw values like above or reference ConfigMaps and Secrets.
 
 <details>
-<summary>Example of a database referencing a ConfigMap resource</summary>
+<summary>Example of a database referencing ConfigMap and Secret resource</summary>
 
 ```yaml
 apiVersion: lunar.bank/v1beta1
@@ -38,6 +40,11 @@ metadata:
   name: user
 spec:
   name: user
+  password:
+    valueFrom:
+      secretKeyRef:
+        name: user-db
+        key: db.password
   host:
     valueFrom:
       configMapKeyRef:

--- a/README.md
+++ b/README.md
@@ -5,28 +5,89 @@ Its purpose is to make a codified description of what users have access to what 
 
 # Design
 
-The controller defines a Kubernetes [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) called `PostgreSQLUser`.  
-It contains metadata about the user along with its access rights to databases.
+The controller will handle user and database management on PostgreSQL instances with two Kubernetes [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
-This is an example of a user `bso` that has the role `iam_developer` and write access to the `user` database between 10 AM to 2 PM on september 9th.
+## Databases
+
+The CRD `PostgreSQLDatabase` specified details about a database on a specific instance.
+It is scoped as cluster wide ie. has no namespace.
+
+The main purpose of this resource is to create databases on a specific host with a specific name used by application services.
+Instances of `PostgreSQLUser` can then give a specific developer access to the database by referenceing the name.
 
 ```yaml
 apiVersion: lunar.bank/v1beta1
+kind: PostgreSQLDatabase
+metadata:
+  name: user
+spec:
+  name: user
+  host:
+    value: some.host.com
+```
+
+The `host` field is modelled like Kubernetes core's [`EnvVarSource`](https://github.com/kubernetes/api/blob/665c8a257c1af277521b08dd43d5c73570405ef0/core/v1/types.go#L1847-L1862), so it can specify raw values like above or reference ConfigMaps etc.
+
+<details>
+<summary>Example of a database referencing a ConfigMap resource</summary>
+
+```yaml
+apiVersion: lunar.bank/v1beta1
+kind: PostgreSQLDatabase
+metadata:
+  name: user
+spec:
+  name: user
+  host:
+    valueFrom:
+      configMapKeyRef:
+        name: database
+        key: db.host
+```
+</details>
+
+The controller will ensure that a database exists on the host based on its configuration.  
+If a resources is deleted we *might* delete the database in the future, preferrable behind a flag to avoid loosing data.
+
+## Users
+
+The CRD `PostgreSQLUser` contains metadata about the user along with its access rights to databases.
+
+The access rights are devided into read and write and specifies a `host` and `reason` as a minimum.
+This `database` field is required for writes along with `start` and `end`.
+This ensures no unnecessary capabilities are left on a user ie. after completing a support ticket.
+
+For reads, it will default to all databases on the instance and requires no time limit.
+We generally do not limit access to data but instead rely on strong audits.
+
+This is an example of a user `bso` that has read access to all databases and write access to the `user` database between 10 AM to 2 PM on september 9th.
+The read capability uses a static host name `some.host.com` and the write capability references a `database` ConfigMap on key `db.host`.
+
+```yaml
+apiVersion: lunar.bank/v1
 kind: PostgreSQLUser
 metadata:
   name: bso
-  namespace: dev
 spec:
-  role: iam_developer
-  reason: "I am a developer"
+  name: bso
+  read:
+  - host: 
+      value: some.host.com
+    reason: "I am a developer"
   write:
-  - database: user
+  - host: 
+      valueFrom:
+        configMapKeyRef:
+          name: database
+          key: db.host
+    database: user
     reason: "Related to support ticket LW-1234"
     start: 2019-09-16T10:00:00Z
     end: 2019-09-16T14:00:00Z
 ```
 
-Users are created with the `rds_iam` role allowing them to sign in with a short lived password issued from AWS.
+From the configuration the user will be created with an `iam_<name>` user on the host and granted rights to access the required databases.
+Further the role `rds_iam` will be granted allowing the user to sign in with IAM credentials.
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ spec:
       end: 2019-09-16T14:00:00Z
 ```
 
-From the configuration the user will be created with an `iam_<name>` user on the host and granted rights to access the required databases.
+From the configuration the user will be created with an `iam_developer_<name>` user on the host and granted rights to access the required databases.
 Further the role `rds_iam` will be granted allowing the user to sign in with IAM credentials.
 
 A policy will also be added to AWS IAM for the specific user allowing it to connect to the host.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A policy will also be added to AWS IAM for the specific user allowing it to conn
       "Effect": "Allow",
       "Action": ["rds-db:connect"],
       "Resource": [
-        "arn:aws:rds-db:region:instance:dbuser:*/iam_<name>"
+        "arn:aws:rds-db:region:account:dbuser:*/iam_<name>"
       ],
       "Condition": {
         "StringLike": {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The CRD `PostgreSQLDatabase` specified details about a database on a specific in
 It is scoped as cluster wide ie. has no namespace.
 
 The main purpose of this resource is to create databases on a specific host with a specific name used by application services.
-Instances of `PostgreSQLUser` can then give a specific developer access to the database by referenceing the name.
+Instances of `PostgreSQLUser` can then give a specific developer access to the database by referencing the name.
 
 ```yaml
 apiVersion: lunar.bank/v1beta1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # PostgreSQL controller
 
+This is a Kubernetes controller for managing users and their access rights to a PostgreSQL database instance.
+Its purpose is to make a codified description of what users have access to what databases and for what reason along with providing an auditable log of changes.
+
+# Design
+
+The controller defines a Kubernetes [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) called `PostgreSQLUser`.  
+It contains metadata about the user along with its access rights to databases.
+
+This is an example of a user `bso` that has the role `iam_developer` and write access to the `user` database between 10 AM to 2 PM on september 9th.
+
+```yaml
+apiVersion: lunar.bank/v1beta1
+kind: PostgreSQLUser
+metadata:
+  name: bso
+  namespace: dev
+spec:
+  role: iam_developer
+  reason: "I am a developer"
+  write:
+  - database: user
+    reason: "Related to support ticket LW-1234"
+    start: 2019-09-16T10:00:00Z
+    end: 2019-09-16T14:00:00Z
+```
+
+Users are created with the `rds_iam` role allowing them to sign in with a short lived password issued from AWS.
+
 # Development
 
 This project uses the [Operator SDK framework](https://github.com/operator-framework/operator-sdk) and its associated CLI.  


### PR DESCRIPTION
This PR adds documentation of the design based on our IFD and access control drafts.

Its goal is to document how to use the controller, ie. CRDs, along with how the controllers own database access is managed.

# 
# Things not clear yet

## How to specify read access?
I don't find the `role: iam_developer` that good as it's an implementation detail that shows.

Maybe just a `read` object with a reason for now?
```yaml
spec:
  read:
    reason: "I am a developer"
```

This could lead to a more granular approach to read access as well if we in the future intend for that.

## How to specify the hosts of databases for read/write access?

Should we add a `host` field to the rights object?

```yaml
apiVersion: lunar.bank/v1
kind: PostgreSQLUser
metadata:
  name: bso
spec:
  name: bso
  read:
  - host: some.host.com
    reason: "I am a developer"
  write:
  - host: some.host.com
    database: user
    reason: "Related to support ticket LW-1234"
    start: 2019-09-16T10:00:00Z
    end: 2019-09-16T14:00:00Z
```

If it is possible to reference another resource field like in env variables in deployments, it could simplify management of these objects.

```yaml
host:
  valueFrom:
    configMapKeyRef:
      name: database
      key: db.host
```

## How to specify databases?

Maybe a simple CR defining the names and host it should be created on?
The controller would then ensure to create this database and grant users access to it.
It should also be able to create the service user and password for it. In time this password will maybe become short lived as as IAM flow as well, but for now it is static for each service.

```yaml
apiVersion: lunar.bank/v1beta1
kind: PostgreSQLDatabase
metadata:
  name: user
  namespace: dev
spec:
  name: user
  host: some.host.com
```

## How to specify database instance?

Maybe a simple CR defining the names and host it should be created on?
The controller would then ensure to create this database and grant users access to it.
It should also be able to create the service user and password for it. In time this password will maybe become short lived as as IAM flow as well, but for now it is static for each service.

```yaml
apiVersion: lunar.bank/v1beta1
kind: PostgreSQLInstance
metadata:
  name: user
  namespace: dev
spec:
  name: user
  storage: 1GB
  instanceTypes: m4.large
  # ...
```