### PR TITLE
Move generic kube client methods into own package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191030232758-662d20b8a76e
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
-	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
+	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/kube-openapi v0.0.0-20190401085232-94e1e7b7574c
-	sigs.k8s.io/controller-runtime v0.2.0
+	sigs.k8s.io/controller-runtime v0.3.0
 )
 
 // Pinned to kubernetes-1.14.1

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -184,6 +185,8 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -206,6 +209,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
+github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.0.0-20190301152420-fca40860790e/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.2.0 h1:lD2Bce2xBAMNNcFZ0dObTpXkGLlVIb33RPVUNVpw6ic=
 github.com/gophercloud/gophercloud v0.2.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
@@ -598,6 +603,8 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190501045030-23463209683d/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -702,6 +709,7 @@ sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHE
 sigs.k8s.io/controller-runtime v0.2.0 h1:5gL30PXOisGZl+Osi4CmLhvMUj77BO3wJeouKF2va50=
 sigs.k8s.io/controller-runtime v0.2.0/go.mod h1:ZHqrRDZi3f6BzONcvlUxkqCKgwasGk5FZrnSv9TVZF4=
 sigs.k8s.io/controller-runtime v0.3.0 h1:ZtdgqJXVHsIytjdmDuk0QjagnzyLq9FjojXRqIp+dU4=
+sigs.k8s.io/controller-runtime v0.3.0/go.mod h1:Cw6PkEg0Sa7dAYovGT4R0tRkGhHXpYijwNxYhAnAZZk=
 sigs.k8s.io/controller-tools v0.2.0/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -142,3 +142,10 @@ func (r *ReconcilePostgreSQLUser) ensurePostgreSQLRole(log logr.Logger, name str
 	}
 	return nil
 }
+
+// func (r *ReconcilePostgreSQLUser) buildRights(reads []lunarwayv1alpha1.ReadAccessSpec) {
+// 	hosts := make(map[string][]lunarwayv1alpha1.ReadAccessSpec)
+// 	for _, access := range reads {
+// 		host :=
+// 	}
+// }

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -142,10 +142,3 @@ func (r *ReconcilePostgreSQLUser) ensurePostgreSQLRole(log logr.Logger, name str
 	}
 	return nil
 }
-
-// func (r *ReconcilePostgreSQLUser) buildRights(reads []lunarwayv1alpha1.ReadAccessSpec) {
-// 	hosts := make(map[string][]lunarwayv1alpha1.ReadAccessSpec)
-// 	for _, access := range reads {
-// 		host :=
-// 	}
-// }

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"go.lunarway.com/postgresql-controller/test"
 )
 
 func TestReconcile_ensurePostgreSQLRole(t *testing.T) {
@@ -88,8 +88,7 @@ func TestReconcile_ensurePostgreSQLRole(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := testLogger{t: t}
-			logf.SetLogger(logf.ZapLoggerTo(&logger, true))
+			log := test.SetLogger(t)
 
 			userName := fmt.Sprintf("test_user_%d", time.Now().UnixNano())
 			t.Logf("Using user name %s", userName)
@@ -112,7 +111,7 @@ func TestReconcile_ensurePostgreSQLRole(t *testing.T) {
 			}
 
 			// act
-			err = r.ensurePostgreSQLRole(logf.Log, userName)
+			err = r.ensurePostgreSQLRole(log, userName)
 
 			// assert
 			assert.NoError(t, err, "unexpected output error")

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -1,0 +1,34 @@
+package kube
+
+import (
+	"context"
+	"encoding/base64"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func SecretValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {
+	secret := &corev1.Secret{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, secret)
+	if err != nil {
+		return "", err
+	}
+	//TODO: Add guard against non-existing keys
+	password, err := base64.StdEncoding.DecodeString(string(secret.Data[key]))
+	if err != nil {
+		return "", err
+	}
+	return string(password), nil
+}
+
+func ConfigMapValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {
+	configMap := &corev1.ConfigMap{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, configMap)
+	if err != nil {
+		return "", err
+	}
+	//TODO: Add guard against non-existing keys
+	return string(configMap.Data[key]), nil
+}

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -3,11 +3,30 @@ package kube
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
+	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/pkg/apis/lunarway/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ResourceValue returns the value of a ResourceVar in a specific namespace.
+func ResourceValue(client client.Client, resource lunarwayv1alpha1.ResourceVar, namespace string) (string, error) {
+	if resource.Value != "" {
+		return resource.Value, nil
+	}
+
+	if resource.ValueFrom.SecretKeyRef.Key != "" {
+		return SecretValue(client, types.NamespacedName{Name: resource.ValueFrom.SecretKeyRef.Name, Namespace: namespace}, resource.ValueFrom.SecretKeyRef.Key)
+	}
+
+	if resource.ValueFrom.ConfigMapKeyRef.Key != "" {
+		return ConfigMapValue(client, types.NamespacedName{Name: resource.ValueFrom.ConfigMapKeyRef.Name, Namespace: namespace}, resource.ValueFrom.ConfigMapKeyRef.Key)
+	}
+
+	return "", fmt.Errorf("no value")
+}
 
 func SecretValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {
 	secret := &corev1.Secret{}

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -1,0 +1,135 @@
+package kube_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lunarway.com/postgresql-controller/pkg/kube"
+	"go.lunarway.com/postgresql-controller/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSecretValue(t *testing.T) {
+	tt := []struct {
+		name       string
+		secretName string
+		namespace  string
+		key        string
+		value      string
+		output     string
+		err        error
+	}{
+		{
+			name:       "sunshine",
+			secretName: "test",
+			namespace:  "test",
+			key:        "test",
+			value:      "dGVzdA==",
+			output:     "test",
+			err:        nil,
+		},
+		{
+			name:       "illegal base64",
+			secretName: "test",
+			namespace:  "test",
+			key:        "test",
+			value:      "dGVzdA",
+			output:     "",
+			err:        errors.New("illegal base64 data at input byte 4"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			test.SetLogger(t)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.secretName,
+					Namespace: tc.namespace,
+				},
+				Data: map[string][]byte{
+					tc.key: []byte(tc.value),
+				},
+			}
+			// Objects to track in the fake client.
+			objs := []runtime.Object{
+				secret,
+			}
+
+			// Create a fake client to mock API calls.
+			cl := fake.NewFakeClient(objs...)
+
+			namespacedName := types.NamespacedName{
+				Name:      tc.secretName,
+				Namespace: tc.namespace,
+			}
+
+			password, err := kube.SecretValue(cl, namespacedName, tc.key)
+			if tc.err != nil {
+				assert.EqualErrorf(t, err, tc.err.Error(), "wrong output error: %v", err.Error())
+			} else {
+				assert.NoError(t, err, "unexpected output error")
+			}
+			assert.Equal(t, tc.output, password, "password not as expected")
+		})
+	}
+}
+
+func TestReconcilePostgreSQLDatabase_getConfigMapValue(t *testing.T) {
+	tt := []struct {
+		name          string
+		configMapName string
+		namespace     string
+		key           string
+		value         string
+		output        string
+		err           error
+	}{
+		{
+			name:          "sunshine",
+			configMapName: "test",
+			namespace:     "test",
+			key:           "test",
+			value:         "test",
+			output:        "test",
+			err:           nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			test.SetLogger(t)
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.configMapName,
+					Namespace: tc.namespace,
+				},
+				Data: map[string]string{
+					tc.key: tc.value,
+				},
+			}
+			// Objects to track in the fake client.
+			objs := []runtime.Object{
+				configMap,
+			}
+
+			// Create a fake client to mock API calls.
+			cl := fake.NewFakeClient(objs...)
+
+			namespacedName := types.NamespacedName{
+				Name:      tc.configMapName,
+				Namespace: tc.namespace,
+			}
+			password, err := kube.ConfigMapValue(cl, namespacedName, tc.key)
+			if tc.err != nil {
+				assert.EqualErrorf(t, err, tc.err.Error(), "wrong output error: %v", err.Error())
+			} else {
+				assert.NoError(t, err, "unexpected output error")
+			}
+			assert.Equal(t, tc.output, password, "password not as expected")
+		})
+	}
+}

--- a/test/log.go
+++ b/test/log.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"io"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func SetLogger(t *testing.T) *log.DelegatingLogger {
+	log.SetLogger(zap.LoggerTo(&logger{t: t}, true))
+	return log.Log
+}
+
+var _ io.Writer = &logger{}
+
+// logger is an io.Writer used for reporting logs to the test runner.
+type logger struct {
+	t *testing.T
+}
+
+func (l *logger) Write(p []byte) (int, error) {
+	l.t.Logf("%s", p)
+	return len(p), nil
+}


### PR DESCRIPTION
This change moves the kube client methods of PostgreSQLDatabase controller into a new package `kube` to be reused in the PostgreSQLUser controller.

Further more the logging setup in tests are moved into package `test` and
controller-runtime is upgrade to latest.