### PR TITLE
Add Integration function to package test

### DIFF
--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller_test.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller_test.go
@@ -3,7 +3,6 @@ package postgresqldatabase
 import (
 	"database/sql"
 	"fmt"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -14,10 +13,7 @@ import (
 )
 
 func TestReconcilePostgreSQLDatabase_ensurePostgreSQLDatabase_sunshine(t *testing.T) {
-	postgresqlHost := os.Getenv("POSTGRESQL_CONTROLLER_INTEGRATION_HOST")
-	if postgresqlHost == "" {
-		t.Skip("Integration test host not specified")
-	}
+	postgresqlHost := test.Integration(t)
 	connectionString := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
 	db, err := postgresqlConnection(connectionString)
 	if err != nil {
@@ -58,10 +54,7 @@ func TestReconcilePostgreSQLDatabase_ensurePostgreSQLDatabase_sunshine(t *testin
 }
 
 func TestReconcilePostgreSQLDatabase_ensurePostgreSQLDatabase_idempotency(t *testing.T) {
-	postgresqlHost := os.Getenv("POSTGRESQL_CONTROLLER_INTEGRATION_HOST")
-	if postgresqlHost == "" {
-		t.Skip("Integration test host not specified")
-	}
+	postgresqlHost := test.Integration(t)
 	connectionString := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
 	db, err := postgresqlConnection(connectionString)
 	if err != nil {

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -15,10 +14,7 @@ import (
 )
 
 func TestReconcile_ensurePostgreSQLRole(t *testing.T) {
-	postgresqlHost := os.Getenv("POSTGRESQL_CONTROLLER_INTEGRATION_HOST")
-	if postgresqlHost == "" {
-		t.Skip("Integration test host not specified")
-	}
+	postgresqlHost := test.Integration(t)
 	connectionString := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
 	db, err := postgresqlConnection(connectionString)
 	if err != nil {

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+// Integration skips the test if no integration PostgreSQL host name is
+// available as an environment variable.
+// If it is available its value is returned.
+func Integration(t *testing.T) string {
+	host := os.Getenv("POSTGRESQL_CONTROLLER_INTEGRATION_HOST")
+	if host == "" {
+		t.Skip("Integration tests not enabled as POSTGRESQL_CONTROLLER_INTEGRATION_HOST is empty")
+	}
+	return host
+}


### PR DESCRIPTION
It handles skipping and reporing for integration tests for simpler use in tests.