### PR TITLE
Handle multiple hosts for database controller

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -83,14 +83,7 @@ type ReconcilePostgreSQLUser struct {
 	awsProfile    string
 
 	// contains a map of credentials for hosts
-	hostCredentials map[string]Credentials
-}
-
-// Credentials represents connection credentials for a user on a
-// PostgreSQL instance capabable of creating roles.
-type Credentials struct {
-	Name     string
-	Password string
+	hostCredentials map[string]postgres.Credentials
 }
 
 // Reconcile reads that state of the cluster for a PostgreSQLUser object and makes changes based on the state read

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -15,15 +15,15 @@ func TestReconcile_connectToHosts(t *testing.T) {
 	test.Integration(t)
 	tt := []struct {
 		name            string
-		credentials     map[string]Credentials
+		credentials     map[string]postgres.Credentials
 		hostAccess      HostAccess
 		connectionCount int
 		err             error
 	}{
 		{
 			name: "single host with credentials",
-			credentials: map[string]Credentials{
-				"localhost:5432": Credentials{
+			credentials: map[string]postgres.Credentials{
+				"localhost:5432": postgres.Credentials{
 					Name:     "iam_creator",
 					Password: "",
 				},
@@ -36,8 +36,8 @@ func TestReconcile_connectToHosts(t *testing.T) {
 		},
 		{
 			name: "multiple hosts with credentials",
-			credentials: map[string]Credentials{
-				"localhost:5432": Credentials{
+			credentials: map[string]postgres.Credentials{
+				"localhost:5432": postgres.Credentials{
 					Name:     "iam_creator",
 					Password: "",
 				},
@@ -50,12 +50,12 @@ func TestReconcile_connectToHosts(t *testing.T) {
 		},
 		{
 			name: "multiple hosts without upstream",
-			credentials: map[string]Credentials{
-				"localhost:5432": Credentials{
+			credentials: map[string]postgres.Credentials{
+				"localhost:5432": postgres.Credentials{
 					Name:     "iam_creator",
 					Password: "",
 				},
-				"unknown": Credentials{
+				"unknown": postgres.Credentials{
 					Name:     "iam_creator",
 					Password: "12345678",
 				},
@@ -69,7 +69,7 @@ func TestReconcile_connectToHosts(t *testing.T) {
 		},
 		{
 			name:        "missing credentials",
-			credentials: map[string]Credentials{},
+			credentials: map[string]postgres.Credentials{},
 			hostAccess: HostAccess{
 				"localhost:5432": []ReadWriteAccess{},
 			},

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -46,6 +46,8 @@ func Database(log logr.Logger, db *sql.DB, credentials Credentials) error {
 		return err
 	}
 
+	// Connect with the newly created role to create the schema with that role. This ensures
+	// that the object is in fact owned by the service and not the creator role.
 	serviceConnection, err := Connect(log, fmt.Sprintf("postgresql://%s:%s@localhost:5432/%s?sslmode=disable", credentials.Name, credentials.Password, credentials.Name))
 	if err != nil {
 		return err

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -1,0 +1,75 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/lib/pq"
+)
+
+// Credentials represents connection credentials for a user on a
+// PostgreSQL instance.
+type Credentials struct {
+	Name     string
+	Password string
+}
+
+func Database(log logr.Logger, db *sql.DB, credentials Credentials) error {
+	// Create the service user
+	_, err := db.Exec(fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'", credentials.Name, credentials.Password))
+	if err != nil {
+		pqError, ok := err.(*pq.Error)
+		if !ok || pqError.Code.Name() != "duplicate_object" {
+			return err
+		}
+		log.Info(fmt.Sprintf("Service user; %s already exists", credentials.Name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+	} else {
+		log.Info(fmt.Sprintf("Service user; %s created", credentials.Name))
+	}
+
+	// Create the database
+	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", credentials.Name))
+	if err != nil {
+		pqError, ok := err.(*pq.Error)
+		if !ok || pqError.Code.Name() != "duplicate_database" {
+			return err
+		}
+		log.Info(fmt.Sprintf("Database; %s already exists", credentials.Name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+	} else {
+		log.Info(fmt.Sprintf("Database; %s created", credentials.Name))
+	}
+
+	// Alter ownership of the database to the database user
+	_, err = db.Exec(fmt.Sprintf("ALTER DATABASE %s OWNER TO %s", credentials.Name, credentials.Name))
+	if err != nil {
+		return err
+	}
+
+	serviceConnection, err := Connect(log, fmt.Sprintf("postgresql://%s:%s@localhost:5432/%s?sslmode=disable", credentials.Name, credentials.Password, credentials.Name))
+	if err != nil {
+		return err
+	}
+
+	// Create schema in the database
+	_, err = serviceConnection.Exec(fmt.Sprintf("CREATE SCHEMA %s", credentials.Name))
+	if err != nil {
+		pqError, ok := err.(*pq.Error)
+		if !ok || pqError.Code.Name() != "duplicate_schema" {
+			return err
+		}
+		log.Info(fmt.Sprintf("Schema; %s already exists in database; %s", credentials.Name, credentials.Name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+	} else {
+		log.Info(fmt.Sprintf("Schema; %s created in database; %s", credentials.Name, credentials.Name))
+	}
+	// This revokation ensures that the user cannot create any objects in the
+	// PUBLIC role that is assigned to all roles by default.
+	log.Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", credentials.Name))
+	_, err = serviceConnection.Exec(fmt.Sprintf(`REVOKE ALL ON DATABASE %s from PUBLIC;
+	REVOKE ALL ON SCHEMA public from PUBLIC;
+	REVOKE ALL ON ALL TABLES IN SCHEMA public from PUBLIC;`, credentials.Name))
+	if err != nil {
+		return fmt.Errorf("revoke all for role PUBLIC on database '%s': %w", credentials.Name, err)
+	}
+	return nil
+}

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"go.lunarway.com/postgresql-controller/pkg/controller/postgresqldatabase"
 	"go.lunarway.com/postgresql-controller/pkg/postgres"
 	"go.lunarway.com/postgresql-controller/test"
 )
@@ -214,10 +213,10 @@ func TestRole_priviliges(t *testing.T) {
 }
 
 func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host, service string) {
-	databaseController := postgresqldatabase.ReconcilePostgreSQLDatabase{
-		DB: database,
-	}
-	err := databaseController.EnsurePostgreSQLDatabase(log, service, "")
+	err := postgres.Database(log, database, postgres.Credentials{
+		Name:     service,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("Failed to create database: %v", err)
 	}


### PR DESCRIPTION
A PostgreSQLDatabase resource specifies what host it requests a database on but
the field was not read.

This changes respects the field by adding a map of host names to credentials.
For each CR a lookup to this map is made to find the proper credentials for
interacting with the host.

The SQL logic is moved to package `postgres` as well.