### PR TITLE
Configuration flags

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -13,6 +13,8 @@ import (
 
 	"go.lunarway.com/postgresql-controller/pkg/apis"
 	"go.lunarway.com/postgresql-controller/pkg/controller"
+	"go.lunarway.com/postgresql-controller/pkg/controller/postgresqldatabase"
+	"go.lunarway.com/postgresql-controller/pkg/controller/postgresqluser"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -52,6 +54,9 @@ func main() {
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	pflag.CommandLine.AddFlagSet(postgresqldatabase.FlagSet)
+	pflag.CommandLine.AddFlagSet(postgresqluser.FlagSet)
 
 	pflag.Parse()
 

--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -26,12 +26,12 @@ var FlagSet *pflag.FlagSet
 
 func init() {
 	FlagSet = pflag.NewFlagSet("controller_postgresqldatabase", pflag.ExitOnError)
-	FlagSet.StringToString("host-credentials", nil, "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
+	FlagSet.StringToString("host-credentials-database", nil, "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
 }
 
 func parseFlags(c *ReconcilePostgreSQLDatabase) {
-	hosts, err := FlagSet.GetStringToString("host-credentials")
-	parseError(err, "host-credentials")
+	hosts, err := FlagSet.GetStringToString("host-credentials-database")
+	parseError(err, "host-credentials-database")
 	fmt.Println(hosts)
 	c.hostCredentials, err = parseHostCredentials(hosts)
 	parseError(err, "host-credentials: invalid format")

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -36,7 +36,7 @@ func init() {
 	FlagSet.String("aws-region", "eu-west-1", "AWS Region where IAM policies are located")
 	FlagSet.String("aws-account-id", "660013655494", "AWS Account id where IAM policies are located")
 	FlagSet.String("aws-profile", "", "AWS Profile to use for credentials")
-	FlagSet.StringToString("host-credentials", nil, "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
+	FlagSet.StringToString("host-credentials-user", nil, "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
 }
 
 func parseFlags(c *ReconcilePostgreSQLUser) {
@@ -53,8 +53,8 @@ func parseFlags(c *ReconcilePostgreSQLUser) {
 	parseError(err, "aws-account")
 	c.awsProfile, err = FlagSet.GetString("aws-profile")
 	parseError(err, "aws-profile")
-	hosts, err := FlagSet.GetStringToString("host-credentials")
-	parseError(err, "host-credentials")
+	hosts, err := FlagSet.GetStringToString("host-credentials-user")
+	parseError(err, "host-credentials-user")
 	c.hostCredentials, err = parseHostCredentials(hosts)
 	parseError(err, "host-credentials: invalid format")
 	var hostNames []string

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
 	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/pkg/apis/lunarway/v1alpha1"
 	"go.lunarway.com/postgresql-controller/pkg/iam"
 	"go.lunarway.com/postgresql-controller/pkg/kube"
@@ -23,7 +24,75 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_postgresqluser")
+var log = logf.Log.WithName("controller_postgresqluser").WithValues("controller", "postgresqluser-controller")
+
+var FlagSet *pflag.FlagSet
+
+func init() {
+	FlagSet = pflag.NewFlagSet("controller_postgresqluser", pflag.ExitOnError)
+	FlagSet.StringSlice("user-roles", []string{"rds_iam"}, "Roles granted to all users")
+	FlagSet.String("user-role-prefix", "iam_developer_", "Prefix of roles created in PostgreSQL for users")
+	FlagSet.String("aws-policy-name", "postgres-controller-users", "AWS Policy name to update IAM statements on")
+	FlagSet.String("aws-region", "eu-west-1", "AWS Region where IAM policies are located")
+	FlagSet.String("aws-account-id", "660013655494", "AWS Account id where IAM policies are located")
+	FlagSet.String("aws-profile", "", "AWS Profile to use for credentials")
+	FlagSet.StringToString("host-credentials", nil, "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
+}
+
+func parseFlags(c *ReconcilePostgreSQLUser) {
+	var err error
+	c.grantRoles, err = FlagSet.GetStringSlice("user-roles")
+	parseError(err, "user-roles")
+	c.rolePrefix, err = FlagSet.GetString("user-role-prefix")
+	parseError(err, "user-role-prefix")
+	c.awsPolicyName, err = FlagSet.GetString("aws-policy-name")
+	parseError(err, "aws-policy-name")
+	c.awsRegion, err = FlagSet.GetString("aws-region")
+	parseError(err, "aws-region")
+	c.awsAccountID, err = FlagSet.GetString("aws-account-id")
+	parseError(err, "aws-account")
+	c.awsProfile, err = FlagSet.GetString("aws-profile")
+	parseError(err, "aws-profile")
+	hosts, err := FlagSet.GetStringToString("host-credentials")
+	parseError(err, "host-credentials")
+	c.hostCredentials, err = parseHostCredentials(hosts)
+	parseError(err, "host-credentials: invalid format")
+	var hostNames []string
+	for host := range c.hostCredentials {
+		hostNames = append(hostNames, host)
+	}
+
+	log.Info("Controller configured",
+		"hosts", hostNames,
+		"roles", c.grantRoles,
+		"prefix", c.rolePrefix,
+		"awsPolicyName", c.awsPolicyName,
+		"awsRegion", c.awsRegion,
+		"awsAccountID", c.awsAccountID,
+	)
+}
+
+func parseError(err error, flag string) {
+	if err != nil {
+		log.Error(err, fmt.Sprintf("error parsing flag %s", flag))
+		os.Exit(1)
+	}
+}
+
+func parseHostCredentials(hosts map[string]string) (map[string]postgres.Credentials, error) {
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	hostCredentials := make(map[string]postgres.Credentials)
+	for host, credentials := range hosts {
+		var err error
+		hostCredentials[host], err = postgres.ParseUsernamePassword(credentials)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return hostCredentials, nil
+}
 
 // Add creates a new PostgreSQLUser Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -33,18 +102,13 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcilePostgreSQLUser{
+	c := &ReconcilePostgreSQLUser{
 		client:           mgr.GetClient(),
 		resourceResolver: kube.ResourceValue,
 		setAWSPolicy:     iam.SetAWSPolicy,
-
-		grantRoles:    []string{"rds_iam", "iam_developer"},
-		rolePrefix:    "iam_developer_",
-		awsPolicyName: "postgresql-controller-users",
-		awsRegion:     "eu-west-1",
-		awsAccountID:  "660013655494",
-		awsProfile:    os.Getenv("AWS_PROFILE"),
 	}
+	parseFlags(c)
+	return c
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -14,7 +14,6 @@ import (
 
 type AWSPolicy struct {
 	Region    string
-	Profile   string
 	AccountID string
 	Name      string
 }
@@ -38,17 +37,17 @@ type UserID struct {
 	AWSUserID string `json:"aws:userid,omitempty"`
 }
 
-func SetAWSPolicy(log logr.Logger, policy AWSPolicy, userID string) error {
+func SetAWSPolicy(log logr.Logger, credentials *credentials.Credentials, policy AWSPolicy, userID string) error {
 	// AWS Config Object to create a session
 	awsConfig := &aws.Config{
 		Region:      aws.String(policy.Region),
-		Credentials: credentials.NewSharedCredentials("", policy.Profile),
+		Credentials: credentials,
 	}
 
 	// Initialize session to AWS
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
-		return fmt.Errorf("session initialization for region %s and profile %s: %w", policy.Region, policy.Profile, err)
+		return fmt.Errorf("session initialization for region %s: %w", policy.Region, err)
 	}
 	svc := iam.New(sess)
 

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/lib/pq"
@@ -13,6 +14,25 @@ import (
 type Credentials struct {
 	Name     string
 	Password string
+}
+
+// ParseUsernamePassword parses string s as a PostgreSQL user name and password
+// pair. If the user name is determined to be empty an error is returned.
+func ParseUsernamePassword(s string) (Credentials, error) {
+	if len(s) == 0 {
+		return Credentials{}, fmt.Errorf("username empty")
+	}
+	pair := strings.SplitN(strings.TrimSpace(s), ":", 2)
+	if len(pair[0]) == 0 {
+		return Credentials{}, fmt.Errorf("username empty")
+	}
+	c := Credentials{
+		Name: pair[0],
+	}
+	if len(pair) == 2 {
+		c.Password = pair[1]
+	}
+	return c, nil
 }
 
 func Database(log logr.Logger, db *sql.DB, credentials Credentials) error {


### PR DESCRIPTION
This PR adds controller configuration with flags.

The configuration fields of both `PostgreSQLUser` and `PostgreSQLDatabase` are
now populated in a `parseFlags` function.

The two flagsets are registered in main and allows each controller to specify
its own flags.

One caveat about this solution is that overlapping flags are ignored. 😞 Package
`pflag` does not allow overlapping flags so `host-credentials` are duplicated
for each controller (`host-credentials-user` and `host-credentials-database`)
even though they are almost always expected to be identical.

I would have like to inject all this configuration from main, but the design of
`operator-sdk` to rely on globals for controller registrations makes injection
of the values very challenging.