### PR TITLE
Only mask passwords of connection string

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -279,7 +279,10 @@ func (r *ReconcilePostgreSQLUser) connectToHosts(accesses HostAccess) (map[strin
 		connectionString := fmt.Sprintf("postgresql://%s:%s@%s?sslmode=disable", credentials.Name, credentials.Password, host)
 		db, err := postgres.Connect(log, connectionString)
 		if err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("connect to %s: %w", strings.ReplaceAll(connectionString, credentials.Password, "***"), err))
+			if len(credentials.Password) != 0 {
+				connectionString = strings.ReplaceAll(connectionString, credentials.Password, "***")
+			}
+			errs = multierr.Append(errs, fmt.Errorf("connect to %s: %w", connectionString, err))
 			continue
 		}
 		hosts[host] = db


### PR DESCRIPTION
If the password is empty [`strings.ReplaceAll`](https://golang.org/pkg/strings/#ReplaceAll) will add the mask *** between all
characters in the connection string.

This change ensures to only apply the mask if the password is set.