### PR TITLE
Remove fmt.Println

### DIFF
--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -32,7 +32,6 @@ func init() {
 func parseFlags(c *ReconcilePostgreSQLDatabase) {
 	hosts, err := FlagSet.GetStringToString("host-credentials-database")
 	parseError(err, "host-credentials-database")
-	fmt.Println(hosts)
 	c.hostCredentials, err = parseHostCredentials(hosts)
 	parseError(err, "host-credentials: invalid format")
 	var hostNames []string


### PR DESCRIPTION
Mistakenly left in the code from debugging host parsing.