### PR TITLE
Lookup connections without database suffix

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -30,21 +30,7 @@ func TestReconcile_connectToHosts(t *testing.T) {
 				},
 			},
 			hostAccess: HostAccess{
-				"localhost:5432": []ReadWriteAccess{},
-			},
-			connectionCount: 1,
-			err:             nil,
-		},
-		{
-			name: "multiple hosts with credentials",
-			credentials: map[string]postgres.Credentials{
-				"localhost:5432": postgres.Credentials{
-					Name:     "iam_creator",
-					Password: "",
-				},
-			},
-			hostAccess: HostAccess{
-				"localhost:5432": []ReadWriteAccess{},
+				"localhost:5432/postgres": []ReadWriteAccess{},
 			},
 			connectionCount: 1,
 			err:             nil,
@@ -62,17 +48,17 @@ func TestReconcile_connectToHosts(t *testing.T) {
 				},
 			},
 			hostAccess: HostAccess{
-				"localhost:5432": []ReadWriteAccess{},
-				"unknown":        []ReadWriteAccess{},
+				"localhost:5432/postgres": []ReadWriteAccess{},
+				"unknown/postgres":        []ReadWriteAccess{},
 			},
 			connectionCount: 1,
-			err:             fmt.Errorf("connect to postgresql://iam_creator:***@unknown?sslmode=disable: dial tcp: lookup unknown: no such host"),
+			err:             fmt.Errorf("connect to postgresql://iam_creator:***@unknown/postgres?sslmode=disable: dial tcp: lookup unknown: no such host"),
 		},
 		{
 			name:        "missing credentials",
 			credentials: map[string]postgres.Credentials{},
 			hostAccess: HostAccess{
-				"localhost:5432": []ReadWriteAccess{},
+				"localhost:5432/postgres": []ReadWriteAccess{},
 			},
 			connectionCount: 0,
 			err:             fmt.Errorf("no credentials for host 'localhost:5432'"),


### PR DESCRIPTION
The controller is configured with host credentials based on the host and not the
specific database on the host.

Method `connectToHosts` did not take this into account so the credentials lookup
would fail even through valid credentials were applied.

This change strips the host name's database suffix before making the credentials
lookup making sure this works as expected.