### PR TITLE
Add hostname to postgres.Database function

### DIFF
--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -163,7 +163,7 @@ func (r *ReconcilePostgreSQLDatabase) EnsurePostgreSQLDatabase(log logr.Logger, 
 	if err != nil {
 		return fmt.Errorf("connect to host: %w", err)
 	}
-	err = postgres.Database(log, db, postgres.Credentials{
+	err = postgres.Database(log, db, host, postgres.Credentials{
 		Name:     name,
 		Password: password,
 	})

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -35,7 +35,7 @@ func ParseUsernamePassword(s string) (Credentials, error) {
 	return c, nil
 }
 
-func Database(log logr.Logger, db *sql.DB, credentials Credentials) error {
+func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials) error {
 	// Create the service user
 	_, err := db.Exec(fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'", credentials.Name, credentials.Password))
 	if err != nil {
@@ -68,7 +68,7 @@ func Database(log logr.Logger, db *sql.DB, credentials Credentials) error {
 
 	// Connect with the newly created role to create the schema with that role. This ensures
 	// that the object is in fact owned by the service and not the creator role.
-	serviceConnection, err := Connect(log, fmt.Sprintf("postgresql://%s:%s@localhost:5432/%s?sslmode=disable", credentials.Name, credentials.Password, credentials.Name))
+	serviceConnection, err := Connect(log, fmt.Sprintf("postgresql://%s:%s@%s/%s?sslmode=disable", credentials.Name, credentials.Password, host, credentials.Name))
 	if err != nil {
 		return fmt.Errorf("connect with new user %s: %w", credentials.Name, err)
 	}

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -86,7 +86,7 @@ func TestDatabase_sunshine(t *testing.T) {
 	name := fmt.Sprintf("test_%d", time.Now().UnixNano())
 	password := "test"
 
-	err = postgres.Database(logf.Log, db, postgres.Credentials{
+	err = postgres.Database(logf.Log, db, postgresqlHost, postgres.Credentials{
 		Name:     name,
 		Password: password,
 	})
@@ -126,7 +126,7 @@ func TestDatabase_idempotency(t *testing.T) {
 	name := fmt.Sprintf("test_%d", time.Now().UnixNano())
 	password := "test"
 
-	err = postgres.Database(log, db, postgres.Credentials{
+	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
 		Name:     name,
 		Password: password,
 	})
@@ -135,7 +135,7 @@ func TestDatabase_idempotency(t *testing.T) {
 	}
 
 	// Invoke again with same name
-	err = postgres.Database(log, db, postgres.Credentials{
+	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
 		Name:     name,
 		Password: password,
 	})

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -271,7 +271,7 @@ func TestRole_priviliges(t *testing.T) {
 }
 
 func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host, service string) {
-	err := postgres.Database(log, database, postgres.Credentials{
+	err := postgres.Database(log, database, host, postgres.Credentials{
 		Name:     service,
 		Password: "",
 	})


### PR DESCRIPTION
When a database is created a schema with the same name is created with the newly
created service role. A bug in this handling would try to connect to localhost
when creating the schema 🤦‍♂ . This works in the integration tests where the database
is located on localhost but in a cluster this fails.

This change adds a host parameter to the Database function ensuring that we
connect to the right host when connecting with the service role.