### PR TITLE
Add test postgresql service object

### DIFF
--- a/test/postgresql.yaml
+++ b/test/postgresql.yaml
@@ -23,3 +23,15 @@ spec:
         env:
           - name: POSTGRES_USER
             value: iam_creator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+spec:
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  selector:
+    app: postgresql


### PR DESCRIPTION
This will allow the controller to run inside the cluster and resolve the
postgresql instance running in it.