### PR TITLE
Harden kube functions

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -17,11 +17,11 @@ func ResourceValue(client client.Client, resource lunarwayv1alpha1.ResourceVar, 
 		return resource.Value, nil
 	}
 
-	if resource.ValueFrom.SecretKeyRef.Key != "" {
+	if resource.ValueFrom != nil && resource.ValueFrom.SecretKeyRef != nil && resource.ValueFrom.SecretKeyRef.Key != "" {
 		return SecretValue(client, types.NamespacedName{Name: resource.ValueFrom.SecretKeyRef.Name, Namespace: namespace}, resource.ValueFrom.SecretKeyRef.Key)
 	}
 
-	if resource.ValueFrom.ConfigMapKeyRef.Key != "" {
+	if resource.ValueFrom != nil && resource.ValueFrom.ConfigMapKeyRef != nil && resource.ValueFrom.ConfigMapKeyRef.Key != "" {
 		return ConfigMapValue(client, types.NamespacedName{Name: resource.ValueFrom.ConfigMapKeyRef.Name, Namespace: namespace}, resource.ValueFrom.ConfigMapKeyRef.Key)
 	}
 

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/pkg/apis/lunarway/v1alpha1"
 	"go.lunarway.com/postgresql-controller/pkg/kube"
 	"go.lunarway.com/postgresql-controller/test"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,103 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestResourceValue(t *testing.T) {
+	tt := []struct {
+		name      string
+		resource  lunarwayv1alpha1.ResourceVar
+		namespace string
+		objs      []runtime.Object
+		output    string
+		err       error
+	}{
+		{
+			name: "raw value resource",
+			resource: lunarwayv1alpha1.ResourceVar{
+				Value: "hello",
+			},
+			namespace: "default",
+			objs:      nil,
+			output:    "hello",
+			err:       nil,
+		},
+		{
+			name: "secret value resource",
+			resource: lunarwayv1alpha1.ResourceVar{
+				ValueFrom: &lunarwayv1alpha1.ResourceVarSource{
+					SecretKeyRef: &lunarwayv1alpha1.KeySelector{
+						Name: "secret",
+						Key:  "key",
+					},
+				},
+			},
+			namespace: "default",
+			objs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"key": []byte("dGVzdA=="),
+					},
+				},
+			},
+			output: "test",
+			err:    nil,
+		},
+		{
+			name: "config map resource",
+			resource: lunarwayv1alpha1.ResourceVar{
+				ValueFrom: &lunarwayv1alpha1.ResourceVarSource{
+					ConfigMapKeyRef: &lunarwayv1alpha1.KeySelector{
+						Name: "configmap",
+						Key:  "key",
+					},
+				},
+			},
+			namespace: "default",
+			objs: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "configmap",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"key": "host",
+					},
+				},
+			},
+			output: "host",
+			err:    nil,
+		},
+		{
+			name: "no value",
+			resource: lunarwayv1alpha1.ResourceVar{
+				Value:     "",
+				ValueFrom: nil,
+			},
+			namespace: "default",
+			objs:      nil,
+			output:    "",
+			err:       errors.New("no value"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewFakeClient(tc.objs...)
+
+			value, err := kube.ResourceValue(client, tc.resource, tc.namespace)
+
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error(), "output error not as expected")
+			} else {
+				assert.NoError(t, err, "output error unexpected")
+			}
+			assert.Equal(t, tc.output, value, "output not as expected")
+		})
+	}
+}
 
 func TestSecretValue(t *testing.T) {
 	tt := []struct {

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -177,7 +177,7 @@ func TestSecretValue(t *testing.T) {
 	}
 }
 
-func TestReconcilePostgreSQLDatabase_getConfigMapValue(t *testing.T) {
+func TestConfigMapValue(t *testing.T) {
 	tt := []struct {
 		name          string
 		configMapName string


### PR DESCRIPTION
This PRs hardens the error handling scenarios of the `kube` functions.

Function `ResourceValue` now verifies the existence of value before accessing resource `KeySelector` structs.
This fixes a panic when the resources reference `ConfigMap`s as the secret value is evaluated first and non-existent.

A guard on non-existing keys is added as well so custom resources referencing unknown fields of a config map or secret will be detected.

Lastly I renamed a test case that was no longer correct after moving the functionality out of package `postgresqldatabase`.