### PR TITLE
Mask connection string

### DIFF
--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -159,7 +159,12 @@ func (r *ReconcilePostgreSQLDatabase) EnsurePostgreSQLDatabase(log logr.Logger, 
 	if !ok {
 		return fmt.Errorf("unknown credentials for host %s", host)
 	}
-	db, err := postgres.Connect(log, fmt.Sprintf("postgresql://%s:%s@%s?sslmode=disable", credentials.Name, credentials.Password, host))
+	db, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     host,
+		Database: "",
+		User:     credentials.Name,
+		Password: credentials.Password,
+	})
 	if err != nil {
 		return fmt.Errorf("connect to host: %w", err)
 	}

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -280,12 +280,14 @@ func (r *ReconcilePostgreSQLUser) connectToHosts(accesses HostAccess) (map[strin
 			errs = multierr.Append(errs, fmt.Errorf("no credentials for host '%s'", host))
 			continue
 		}
-		connectionString := fmt.Sprintf("postgresql://%s:%s@%s?sslmode=disable", credentials.Name, credentials.Password, hostDatabase)
+		connectionString := postgres.ConnectionString{
+			Host:     hostDatabase,
+			Database: "",
+			User:     credentials.Name,
+			Password: credentials.Password,
+		}
 		db, err := postgres.Connect(log, connectionString)
 		if err != nil {
-			if len(credentials.Password) != 0 {
-				connectionString = strings.ReplaceAll(connectionString, credentials.Password, "***")
-			}
 			errs = multierr.Append(errs, fmt.Errorf("connect to %s: %w", connectionString, err))
 			continue
 		}

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -52,7 +52,7 @@ func TestReconcile_connectToHosts(t *testing.T) {
 				"unknown/postgres":        []ReadWriteAccess{},
 			},
 			connectionCount: 1,
-			err:             fmt.Errorf("connect to postgresql://iam_creator:***@unknown/postgres?sslmode=disable: dial tcp: lookup unknown: no such host"),
+			err:             fmt.Errorf("connect to postgresql://iam_creator:********@unknown/postgres?sslmode=disable: dial tcp: lookup unknown: no such host"),
 		},
 		{
 			name:        "missing credentials",

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -68,7 +68,12 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials)
 
 	// Connect with the newly created role to create the schema with that role. This ensures
 	// that the object is in fact owned by the service and not the creator role.
-	serviceConnection, err := Connect(log, fmt.Sprintf("postgresql://%s:%s@%s/%s?sslmode=disable", credentials.Name, credentials.Password, host, credentials.Name))
+	serviceConnection, err := Connect(log, ConnectionString{
+		Host:     host,
+		Database: credentials.Name,
+		User:     credentials.Name,
+		Password: credentials.Password,
+	})
 	if err != nil {
 		return fmt.Errorf("connect with new user %s: %w", credentials.Name, err)
 	}

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -77,8 +77,12 @@ func TestParseHostCredentials(t *testing.T) {
 func TestDatabase_sunshine(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	connectionString := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
-	db, err := postgres.Connect(log, connectionString)
+	db, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: "",
+		User:     "iam_creator",
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -94,8 +98,12 @@ func TestDatabase_sunshine(t *testing.T) {
 		t.Fatalf("EnsurePostgreSQLDatabase failed: %v", err)
 	}
 
-	serviceConnectionString := fmt.Sprintf("postgresql://%s:%s@%s/%s?sslmode=disable", name, password, postgresqlHost, name)
-	newDB, err := postgres.Connect(log, serviceConnectionString)
+	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: name,
+		User:     name,
+		Password: password,
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -117,8 +125,12 @@ func TestDatabase_sunshine(t *testing.T) {
 func TestDatabase_idempotency(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	connectionString := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
-	db, err := postgres.Connect(log, connectionString)
+	db, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: "",
+		User:     "iam_creator",
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -1,6 +1,7 @@
 package postgres_test
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"sort"
@@ -12,13 +13,94 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.lunarway.com/postgresql-controller/pkg/postgres"
 	"go.lunarway.com/postgresql-controller/test"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+func TestConnectionString_Raw(t *testing.T) {
+	tt := []struct {
+		name             string
+		connectionString postgres.ConnectionString
+		raw              string
+	}{
+		{
+			name: "no password or database",
+			connectionString: postgres.ConnectionString{
+				Host:     "host:5432",
+				Database: "",
+				User:     "user",
+				Password: "",
+			},
+			raw: "postgresql://user:@host:5432?sslmode=disable",
+		},
+		{
+			name: "no password",
+			connectionString: postgres.ConnectionString{
+				Host:     "host:5432",
+				Database: "database",
+				User:     "user",
+				Password: "",
+			},
+			raw: "postgresql://user:@host:5432/database?sslmode=disable",
+		},
+		{
+			name: "complete",
+			connectionString: postgres.ConnectionString{
+				Host:     "host:5432",
+				Database: "database",
+				User:     "user",
+				Password: "1234",
+			},
+			raw: "postgresql://user:1234@host:5432/database?sslmode=disable",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := tc.connectionString.Raw()
+			assert.Equal(t, tc.raw, raw, "raw connection string not as expected")
+		})
+	}
+}
+
+// TestConnectionString_String tests that ConnectionString does not expose
+// password for fmt.Stringer and fmt.Formatter
+func TestConnectionString_String(t *testing.T) {
+	connectionString := postgres.ConnectionString{
+		Host:     "host:5432",
+		Database: "database",
+		User:     "user",
+		Password: "1234",
+	}
+	expected := "postgresql://user:********@host:5432/database?sslmode=disable"
+	assert.Equal(t, fmt.Sprintf("%s", connectionString), expected, "connection string not as expected")
+	assert.Equal(t, fmt.Sprintf("%v", connectionString), expected, "connection string not as expected")
+	assert.Equal(t, expected, connectionString.String(), "connection string not as expected")
+}
+
+// TestConnectionString_logger tests that ConnectionString does not expose
+// password for the logging implementation.
+func TestConnectionString_logger(t *testing.T) {
+	connectionString := postgres.ConnectionString{
+		Host:     "host:5432",
+		Database: "database",
+		User:     "user",
+		Password: "1234",
+	}
+	var b bytes.Buffer
+	log.SetLogger(zap.LoggerTo(&b, true))
+	log.Log.Info("Connection string", "conn", connectionString)
+	assert.NotContains(t, string(b.Bytes()), "1234", "password logged")
+}
 
 func TestRole_staticRoles(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	connectionString := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
-	db, err := postgres.Connect(log, connectionString)
+	db, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     "iam_creator",
+		Database: "",
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -116,8 +198,12 @@ func TestRole_priviliges_databaseNameAndSchemaDiffers(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 
-	iamCreatorRootDatabase := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
-	iamCreatorRootDB, err := postgres.Connect(log, iamCreatorRootDatabase)
+	iamCreatorRootDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     "iam_creator",
+		Database: "",
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -137,7 +223,12 @@ func TestRole_priviliges_databaseNameAndSchemaDiffers(t *testing.T) {
 	dbExec(t, iamCreatorRootDB, "GRANT CONNECT ON DATABASE %s TO %s", serviceUser1, roleRDSIAM)
 
 	// reconnect to start a new session with grants from above database creation
-	iamCreatorUserDB, err := postgres.Connect(log, fmt.Sprintf("postgresql://iam_creator:@%s/%s?sslmode=disable", postgresqlHost, serviceUser1))
+	iamCreatorUserDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     "iam_creator",
+		Database: serviceUser1,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -155,7 +246,12 @@ func TestRole_priviliges_databaseNameAndSchemaDiffers(t *testing.T) {
 		return
 	}
 
-	userDB, err := postgres.Connect(log, fmt.Sprintf("postgresql://%s:@%s/%s?sslmode=disable", developerUser, postgresqlHost, serviceUser1))
+	userDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     developerUser,
+		Database: serviceUser1,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("could not connect with new user: %v", err)
 	}
@@ -170,8 +266,12 @@ func TestRole_priviliges(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 
-	iamCreatorRootDatabase := fmt.Sprintf("postgresql://iam_creator:@%s?sslmode=disable", postgresqlHost)
-	iamCreatorRootDB, err := postgres.Connect(log, iamCreatorRootDatabase)
+	iamCreatorRootDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     "iam_creator",
+		Database: "",
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -198,7 +298,12 @@ func TestRole_priviliges(t *testing.T) {
 	//
 
 	// reconnect to start a new session with grants from above database creation
-	iamCreatorUserDB, err := postgres.Connect(log, fmt.Sprintf("postgresql://iam_creator:@%s/%s?sslmode=disable", postgresqlHost, serviceUser1))
+	iamCreatorUserDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     "iam_creator",
+		Database: serviceUser1,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -214,7 +319,12 @@ func TestRole_priviliges(t *testing.T) {
 		return
 	}
 
-	userDB, err := postgres.Connect(log, fmt.Sprintf("postgresql://%s:@%s/%s?sslmode=disable", developerUser, postgresqlHost, serviceUser1))
+	userDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     developerUser,
+		Database: serviceUser1,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("could not connect with new user: %v", err)
 	}
@@ -234,7 +344,12 @@ func TestRole_priviliges(t *testing.T) {
 	//
 
 	// reconnect to start a new session with grants from above database creation
-	iamCreatorUserDB, err = postgres.Connect(log, fmt.Sprintf("postgresql://iam_creator:@%s/%s?sslmode=disable", postgresqlHost, serviceUser2))
+	iamCreatorUserDB, err = postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     "iam_creator",
+		Database: serviceUser2,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
@@ -255,7 +370,12 @@ func TestRole_priviliges(t *testing.T) {
 		return
 	}
 
-	userDB, err = postgres.Connect(log, fmt.Sprintf("postgresql://%s:@%s/%s?sslmode=disable", developerUser, postgresqlHost, serviceUser2))
+	userDB, err = postgres.Connect(log, postgres.ConnectionString{
+		Host:     postgresqlHost,
+		User:     developerUser,
+		Database: serviceUser2,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("could not connect with new user: %v", err)
 	}
@@ -279,8 +399,12 @@ func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host
 		t.Fatalf("Failed to create database: %v", err)
 	}
 
-	serviceUserDatabase := fmt.Sprintf("postgresql://%s:@%s/%s?sslmode=disable", service, host, service)
-	serviceUserDB, err := postgres.Connect(log, serviceUserDatabase)
+	serviceUserDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host:     host,
+		User:     service,
+		Database: service,
+		Password: "",
+	})
 	if err != nil {
 		t.Fatalf("connect to service user failed: %v", err)
 	}

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -72,7 +72,7 @@ func TestConnectionString_String(t *testing.T) {
 		Password: "1234",
 	}
 	expected := "postgresql://user:********@host:5432/database?sslmode=disable"
-	assert.Equal(t, fmt.Sprintf("%s", connectionString), expected, "connection string not as expected")
+	assert.Equal(t, fmt.Sprintf("%s", connectionString), expected, "connection string not as expected") //nolint:gosimple
 	assert.Equal(t, fmt.Sprintf("%v", connectionString), expected, "connection string not as expected")
 	assert.Equal(t, expected, connectionString.String(), "connection string not as expected")
 }
@@ -89,7 +89,7 @@ func TestConnectionString_logger(t *testing.T) {
 	var b bytes.Buffer
 	log.SetLogger(zap.LoggerTo(&b, true))
 	log.Log.Info("Connection string", "conn", connectionString)
-	assert.NotContains(t, string(b.Bytes()), "1234", "password logged")
+	assert.NotContains(t, b.String(), "1234", "password logged")
 }
 
 func TestRole_staticRoles(t *testing.T) {


### PR DESCRIPTION
The type represents a PostgreSQL connection string and method Raw returns the
actual string used for `sql.Open`.

It also masks the password from string serialisation as to avoid accidental
logging passwords.

I've added tests for both `fmt.Sprintf` and the used logging implementation to
ensure that non of them will expose the passwords.