### PR TITLE
Default database connection

### DIFF
--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -159,21 +159,22 @@ func (r *ReconcilePostgreSQLDatabase) EnsurePostgreSQLDatabase(log logr.Logger, 
 	if !ok {
 		return fmt.Errorf("unknown credentials for host %s", host)
 	}
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	connectionString := postgres.ConnectionString{
 		Host:     host,
-		Database: "",
+		Database: "postgres", // default database
 		User:     credentials.Name,
 		Password: credentials.Password,
-	})
+	}
+	db, err := postgres.Connect(log, connectionString)
 	if err != nil {
-		return fmt.Errorf("connect to host: %w", err)
+		return fmt.Errorf("connect to host %s: %w", connectionString, err)
 	}
 	err = postgres.Database(log, db, host, postgres.Credentials{
 		Name:     name,
 		Password: password,
 	})
 	if err != nil {
-		return fmt.Errorf("create database %s on host %s: %w", name, host, err)
+		return fmt.Errorf("create database %s on host %s: %w", name, connectionString, err)
 	}
 	return nil
 }

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -274,15 +274,17 @@ func (r *ReconcilePostgreSQLUser) connectToHosts(accesses HostAccess) (map[strin
 		// hostDatabase contains the host name and the database but we expect host
 		// credentials to be without the database part
 		// This will not work for hosts with multiple / characters
-		host := strings.Split(hostDatabase, "/")[0]
+		hostDatabaseParts := strings.Split(hostDatabase, "/")
+		host := hostDatabaseParts[0]
+		database := hostDatabaseParts[1]
 		credentials, ok := r.hostCredentials[host]
 		if !ok {
 			errs = multierr.Append(errs, fmt.Errorf("no credentials for host '%s'", host))
 			continue
 		}
 		connectionString := postgres.ConnectionString{
-			Host:     hostDatabase,
-			Database: "postgres", // default database
+			Host:     host,
+			Database: database,
 			User:     credentials.Name,
 			Password: credentials.Password,
 		}

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -282,7 +282,7 @@ func (r *ReconcilePostgreSQLUser) connectToHosts(accesses HostAccess) (map[strin
 		}
 		connectionString := postgres.ConnectionString{
 			Host:     hostDatabase,
-			Database: "",
+			Database: "postgres", // default database
 			User:     credentials.Name,
 			Password: credentials.Password,
 		}


### PR DESCRIPTION
This change fixes a bug where implicit database selection can lead to connecting to the wrong database.

We now explicitly specify what database to connect to during database creation.

Further more the host and database name is handled properly in the user controller. Before #22 we set the database host and name from one parameter. We are now explicit about the host and database name.