### PR TITLE
Make sure to push release commit before tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,5 @@ release:
 	git add deploy/operator.yaml
 	git commit -m"Release ${TAG}"
 	git tag ${TAG}
+	git push
 	git push --tags


### PR DESCRIPTION
This ensures that the commit of the tag exists on the remote before building release artifacts.