### PR TITLE
Remove public role revocations

### DIFF
--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -104,10 +104,10 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials)
 	if err != nil {
 		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w", credentials.Name, err)
 	}
-	log.Info("Grant usage of service schema to iam_creator")
-	_, err = serviceConnection.Exec(fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO %s", credentials.Name, "iam_creator"))
+	log.Info("Grant usage on schema to PUBLIC")
+	_, err = serviceConnection.Exec(fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO PUBLIC", credentials.Name))
 	if err != nil {
-		return fmt.Errorf("grant usage on schema '%s': %w", credentials.Name, err)
+		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w", credentials.Name, err)
 	}
 	return nil
 }

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -89,14 +89,5 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials)
 	} else {
 		log.Info(fmt.Sprintf("Schema; %s created in database; %s", credentials.Name, credentials.Name))
 	}
-	// This revokation ensures that the user cannot create any objects in the
-	// PUBLIC role that is assigned to all roles by default.
-	log.Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", credentials.Name))
-	_, err = serviceConnection.Exec(fmt.Sprintf(`REVOKE ALL ON DATABASE %s from PUBLIC;
-	REVOKE ALL ON SCHEMA public from PUBLIC;
-	REVOKE ALL ON ALL TABLES IN SCHEMA public from PUBLIC;`, credentials.Name))
-	if err != nil {
-		return fmt.Errorf("revoke all for role PUBLIC on database '%s': %w", credentials.Name, err)
-	}
 	return nil
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -84,6 +84,7 @@ func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []
 		log.Info(fmt.Sprintf("Role %s created", name))
 	}
 	if len(roles) != 0 {
+		log.Info(fmt.Sprintf("Grant static roles %v", roles))
 		_, err = db.Exec(fmt.Sprintf("GRANT %s TO %s", strings.Join(roles, ", "), name))
 		if err != nil {
 			return fmt.Errorf("grant static roles '%v': %w", roles, err)


### PR DESCRIPTION
It seems they interfere with the `rds_iam` grants so IAM users cannot connect.