### PR TITLE
Integration tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,4 +20,4 @@ jobs:
         run: make code/compile
 
       - name: "Test"
-        run: make test/unit
+        run: make test/integration

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,25 @@ test/unit:
 	@echo Running tests:
 	go test -v -race -cover ./pkg/...
 
+POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER=postgresql-controler-int-test
+
+.PHONY: test/integration/postgresql/run
+test/integration/postgresql/run:
+	@echo Running integration test PostgreSQL instance on localhost:5432:
+	-docker run --rm -p 5432:5432 -e POSTGRES_USER=iam_creator --name ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER} -d timms/postgres-logging:11.5 && sleep 5
+	@echo Database running and iam_creator role created.
+	@echo Attach to instance with 'make test/integration/postgresql/attach'
+
+.PHONY: test/integration/postgresql/attach
+test/integration/postgresql/attach:
+	docker attach ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER}
+
+.PHONY: test/integration/postgresql/stop
+test/integration/postgresql/stop:
+	-docker kill ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER}
+
 .PHONY: test/integration
-test/integration:
+test/integration: test/integration/postgresql/run
 	@echo Running integration tests against PostgreSQL instance on ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST}:
 	POSTGRESQL_CONTROLLER_INTEGRATION_HOST=${POSTGRESQL_CONTROLLER_INTEGRATION_HOST} go test -v -race -cover -count=1 ./pkg/...
 

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -52,7 +52,7 @@ func TestReconcile_connectToHosts(t *testing.T) {
 				"unknown/postgres":        []ReadWriteAccess{},
 			},
 			connectionCount: 1,
-			err:             fmt.Errorf("connect to postgresql://iam_creator:********@unknown/postgres?sslmode=disable: dial tcp: lookup unknown: no such host"),
+			err:             fmt.Errorf("connect to postgresql://iam_creator:********@unknown/postgres?sslmode=disable: dial tcp:"),
 		},
 		{
 			name:        "missing credentials",
@@ -84,7 +84,10 @@ func TestReconcile_connectToHosts(t *testing.T) {
 			// assert
 			t.Logf("Connections: %v", connections)
 			if tc.err != nil {
-				assert.EqualError(t, err, tc.err.Error(), "error not as expected")
+				if !assert.Error(t, err, "an output error was expected") {
+					return
+				}
+				assert.Contains(t, err.Error(), tc.err.Error(), "error not as expected")
 			} else {
 				assert.NoError(t, err, "unexpected output error")
 			}


### PR DESCRIPTION
This change adds make targets for running a PostgreSQL instance in Docker.

When running the `ci` GitHub Action workflow we run `make test/integration`
instead of `test/unit` that will start the PostgreSQL instance before running
the `go test` command.

We need to change the assertion in one of the tests as the error message is
different in the action environment than on a local development machine. In the
action a TCP error like this is returned: `dial tcp: lookup unknown: Temporary
failure in name resolution` where we on development machines get `dial tcp:
lookup unknown: no such host`. It is not important for the test case so now we
assert on a `dial tcp` error and ignore the underlying reason.