### PR TITLE
Use read and readwrite roles for database access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,10 @@ POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER=postgresql-controler-int-test
 .PHONY: test/integration/postgresql/run
 test/integration/postgresql/run:
 	@echo Running integration test PostgreSQL instance on localhost:5432:
-	-docker run --rm -p 5432:5432 -e POSTGRES_USER=admin --name ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER} -d timms/postgres-logging:11.5 && sleep 5 && echo "CREATE USER iam_creator WITH CREATEDB CREATEROLE VALID UNTIL 'infinity';" | psql -hlocalhost -Uadmin -d postgres
+	-docker run --rm -p 5432:5432 -e POSTGRES_USER=admin --name ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER} -d timms/postgres-logging:11.5 && \
+		sleep 5 && \
+		docker exec ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER} \
+		  psql -Uadmin -c "CREATE USER iam_creator WITH CREATEDB CREATEROLE VALID UNTIL 'infinity';"
 	@echo Database running and iam_creator role created.
 	@echo Attach to instance with 'make test/integration/postgresql/attach'
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER=postgresql-controler-int-test
 .PHONY: test/integration/postgresql/run
 test/integration/postgresql/run:
 	@echo Running integration test PostgreSQL instance on localhost:5432:
-	-docker run --rm -p 5432:5432 -e POSTGRES_USER=iam_creator --name ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER} -d timms/postgres-logging:11.5 && sleep 5
+	-docker run --rm -p 5432:5432 -e POSTGRES_USER=admin --name ${POSTGRESQL_CONTROLLER_INTEGRATION_HOST_CONTAINER} -d timms/postgres-logging:11.5 && sleep 5 && echo "CREATE USER iam_creator WITH CREATEDB CREATEROLE VALID UNTIL 'infinity';" | psql -hlocalhost -Uadmin -d postgres
 	@echo Database running and iam_creator role created.
 	@echo Attach to instance with 'make test/integration/postgresql/attach'
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Its purpose is to make a codified description of what users have access to what 
 
 The controller will handle user and database management on PostgreSQL instances with two Kubernetes [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
+The controller needs access to a role in PostreSQL privileged to create databases and roles.
+
+```sql
+CREATE USER iam_creator CREATEDB CREATEROLE PASSWORD 'strongpassword';
+```
+
 ## Databases
 
 The CRD `PostgreSQLDatabase` specified details about a database on a specific instance.
@@ -56,6 +62,12 @@ spec:
 
 The controller will ensure that a database exists on the host based on its configuration.  
 If a resources is deleted we _might_ delete the database in the future, preferrable behind a flag to avoid loosing data.
+
+There are created three roles for all databases.
+One with login priviledges according to the custom resource name and password.
+The other two are `read` and `readwrite` roles used when granting users access to the database.
+They are named as the database with a `_read` and `_readwrite` suffix and have the priviledge to `SELECT` and `SELECT, INSERT, UPDATE, DELETE` respectively.
+Default priviledges no the database ensures that each role have access to objects created by the service role.
 
 ## Users
 

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/lib/pq"
+	"go.uber.org/multierr"
 )
 
 // Credentials represents connection credentials for a user on a
@@ -37,37 +38,46 @@ func ParseUsernamePassword(s string) (Credentials, error) {
 
 func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials) error {
 	// Create the service user
-	_, err := db.Exec(fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'", credentials.Name, credentials.Password))
+	err := createUser(log, db, credentials.Name, credentials.Password)
 	if err != nil {
-		pqError, ok := err.(*pq.Error)
-		if !ok || pqError.Code.Name() != "duplicate_object" {
-			return fmt.Errorf("create user %s: %w", credentials.Name, err)
-		}
-		log.Info(fmt.Sprintf("Service user; %s already exists", credentials.Name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
-	} else {
-		log.Info(fmt.Sprintf("Service user; %s created", credentials.Name))
+		return fmt.Errorf("create service user: %w", err)
+	}
+	var (
+		readRole      = fmt.Sprintf("%s_read", credentials.Name)
+		readWriteRole = fmt.Sprintf("%s_readwrite", credentials.Name)
+	)
+
+	// Create read and readwrite roles that can be used to grant users access to
+	// the objects in this database.
+	err = createRoles(log, db, readRole, readWriteRole)
+	if err != nil {
+		return fmt.Errorf("create service read and readwrite roles: %w", err)
 	}
 
 	// Create the database
-	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", credentials.Name))
+	err = createDatabase(log, db, credentials.Name)
 	if err != nil {
-		pqError, ok := err.(*pq.Error)
-		if !ok || pqError.Code.Name() != "duplicate_database" {
-			return fmt.Errorf("create database %s: %w", credentials.Name, err)
-		}
-		log.Info(fmt.Sprintf("Database; %s already exists", credentials.Name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
-	} else {
-		log.Info(fmt.Sprintf("Database; %s created", credentials.Name))
+		return fmt.Errorf("create service database '%s': %w", credentials.Name, err)
 	}
 
-	// Alter ownership of the database to the database user
-	_, err = db.Exec(fmt.Sprintf("ALTER DATABASE %s OWNER TO %s", credentials.Name, credentials.Name))
+	// Alter ownership of the database to the database user. The current user
+	// needs to belong to the new role before owner ship can be changed.
+	err = execf(db, "GRANT %s TO CURRENT_USER", credentials.Name)
+	if err != nil {
+		return fmt.Errorf("grant new role '%s' to creator role: %w", credentials.Name, err)
+	}
+	err = execf(db, "ALTER DATABASE %s OWNER TO %s", credentials.Name, credentials.Name)
 	if err != nil {
 		return fmt.Errorf("alter owner of database %s: %w", credentials.Name, err)
 	}
+	err = execf(db, "REVOKE %s FROM CURRENT_USER", credentials.Name)
+	if err != nil {
+		return fmt.Errorf("revoke new role '%s' to creator role: %w", credentials.Name, err)
+	}
 
-	// Connect with the newly created role to create the schema with that role. This ensures
-	// that the object is in fact owned by the service and not the creator role.
+	// Connect with the newly created role to create the schema with that role.
+	// This ensures that the object is in fact owned by the service and not the
+	// creator role.
 	serviceConnection, err := Connect(log, ConnectionString{
 		Host:     host,
 		Database: credentials.Name,
@@ -79,24 +89,137 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials)
 	}
 
 	// Create schema in the database
-	_, err = serviceConnection.Exec(fmt.Sprintf("CREATE SCHEMA %s", credentials.Name))
+	err = createSchema(log, serviceConnection, credentials.Name)
 	if err != nil {
-		pqError, ok := err.(*pq.Error)
-		if !ok || pqError.Code.Name() != "duplicate_schema" {
-			return fmt.Errorf("create default schema %s: %w", credentials.Name, err)
-		}
-		log.Info(fmt.Sprintf("Schema; %s already exists in database; %s", credentials.Name, credentials.Name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
-	} else {
-		log.Info(fmt.Sprintf("Schema; %s created in database; %s", credentials.Name, credentials.Name))
+		return fmt.Errorf("create schema '%s' as service user '%[1]s': %w", credentials.Name, err)
 	}
+
+	// set default read and write priviledges on the read and readwrite roles as
+	// to ensure the roles' priviledges apply to all objects created later on.
+	err = setDefaultReadPriviledges(serviceConnection, credentials.Name, readRole)
+	if err != nil {
+		return fmt.Errorf("set default read priviledges for role %s: %w", readRole, err)
+	}
+	err = setDefaultReadWritePriviledges(serviceConnection, credentials.Name, readWriteRole)
+	if err != nil {
+		return fmt.Errorf("set default readwrite priviledges for role %s: %w", readWriteRole, err)
+	}
+
 	// This revokation ensures that the user cannot create any objects in the
 	// PUBLIC role that is assigned to all roles by default.
 	log.Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", credentials.Name))
-	_, err = serviceConnection.Exec(fmt.Sprintf(`REVOKE ALL ON DATABASE %s from PUBLIC;
-	REVOKE ALL ON SCHEMA public from PUBLIC;
-	REVOKE ALL ON ALL TABLES IN SCHEMA public from PUBLIC;`, credentials.Name))
+	err = execf(serviceConnection, `
+		REVOKE ALL ON DATABASE %s from PUBLIC;
+		REVOKE ALL ON SCHEMA public from PUBLIC;
+		REVOKE ALL ON ALL TABLES IN SCHEMA public from PUBLIC;`, credentials.Name)
 	if err != nil {
 		return fmt.Errorf("revoke all for role PUBLIC on database '%s': %w", credentials.Name, err)
+	}
+	// Grant CONNECT privileges to PUBLIC again to ensure new roles are allowed to connect.
+	log.Info("Grant CONNECT to PUBLIC")
+	err = execf(serviceConnection, "GRANT CONNECT ON DATABASE %s TO PUBLIC", credentials.Name)
+	if err != nil {
+		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w", credentials.Name, err)
+	}
+	log.Info("Grant usage on schema to PUBLIC")
+	err = execf(serviceConnection, "GRANT USAGE ON SCHEMA %s TO PUBLIC", credentials.Name)
+	if err != nil {
+		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w", credentials.Name, err)
+	}
+	return nil
+}
+
+func createUser(log logr.Logger, db *sql.DB, name, password string) error {
+	log = log.WithValues("database", name)
+	return idempotentExec(log, db, idempotentExecReq{
+		objectType: "service user",
+		errorCode:  "duplicate_object",
+		query:      fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'", name, password),
+	})
+}
+
+func createDatabase(log logr.Logger, db *sql.DB, name string) error {
+	log = log.WithValues("database", name)
+	return idempotentExec(log, db, idempotentExecReq{
+		objectType: "database",
+		errorCode:  "duplicate_database",
+		query:      fmt.Sprintf("CREATE DATABASE %s", name),
+	})
+}
+
+func createSchema(log logr.Logger, db *sql.DB, name string) error {
+	log = log.WithValues("schema", name)
+	return idempotentExec(log, db, idempotentExecReq{
+		objectType: "schema",
+		errorCode:  "duplicate_schema",
+		query:      fmt.Sprintf("CREATE SCHEMA %s", name),
+	})
+}
+
+func createRoles(log logr.Logger, db *sql.DB, roles ...string) error {
+	var errs error
+	for _, role := range roles {
+		log := log.WithValues("role", role)
+		err := idempotentExec(log, db, idempotentExecReq{
+			objectType: "service role",
+			errorCode:  "duplicate_object",
+			query:      fmt.Sprintf("CREATE ROLE %s", role),
+		})
+		if err != nil {
+			errs = multierr.Append(errs, fmt.Errorf("create role %s: %w", role, err))
+		}
+	}
+	if errs != nil {
+		return errs
+	}
+	return nil
+}
+
+type idempotentExecReq struct {
+	objectType string
+	errorCode  string
+	query      string
+}
+
+func idempotentExec(log logr.Logger, db *sql.DB, args idempotentExecReq) error {
+	_, err := db.Exec(args.query)
+	if err != nil {
+		pqError, ok := err.(*pq.Error)
+		if !ok || pqError.Code.Name() != args.errorCode {
+			return err
+		}
+		log.Info(fmt.Sprintf("%s already exists", args.objectType), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+	} else {
+		log.Info(fmt.Sprintf("%s created", args.objectType))
+	}
+	return nil
+}
+
+func setDefaultReadPriviledges(db *sql.DB, schema string, role string) error {
+	return setDefaultPriviledges(db, schema, role, "SELECT")
+}
+
+func setDefaultReadWritePriviledges(db *sql.DB, schema string, role string) error {
+	return setDefaultPriviledges(db, schema, role, "SELECT, INSERT, UPDATE, DELETE")
+}
+
+func setDefaultPriviledges(db *sql.DB, schema, role, priviledges string) error {
+	err := execf(db, "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT %s ON TABLES TO %s;", schema, priviledges, role)
+	if err != nil {
+		return fmt.Errorf("alter default privileges of schema: %w", err)
+	}
+	err = execf(db, "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT %s ON TABLES TO %s;", priviledges, role)
+	if err != nil {
+		return fmt.Errorf("alter default privileges of public schema: %w", err)
+	}
+	return nil
+}
+
+// execf executes a formatted query on db.
+func execf(db *sql.DB, query string, args ...interface{}) error {
+	_, err := db.Exec(fmt.Sprintf(query, args...))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -79,7 +79,7 @@ func TestDatabase_sunshine(t *testing.T) {
 	log := test.SetLogger(t)
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
-		Database: "",
+		Database: "postgres",
 		User:     "iam_creator",
 		Password: "",
 	})
@@ -127,7 +127,7 @@ func TestDatabase_idempotency(t *testing.T) {
 	log := test.SetLogger(t)
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
-		Database: "",
+		Database: "postgres",
 		User:     "iam_creator",
 		Password: "",
 	})

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -98,16 +98,16 @@ func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []
 		}
 		var schemaPrivileges string
 		if database.Privileges == PrivilegeRead {
-			schemaPrivileges = "SELECT"
+			schemaPrivileges = "read"
 		}
 		if database.Privileges == PrivilegeWrite {
-			schemaPrivileges = "SELECT, INSERT, UPDATE, DELETE"
+			schemaPrivileges = "readwrite"
 		}
 		if len(schemaPrivileges) == 0 {
 			continue
 		}
-		log.Info(fmt.Sprintf("Granting %s to tables in schema '%s'", schemaPrivileges, database.Schema))
-		_, err = db.Exec(fmt.Sprintf("GRANT %s ON ALL TABLES IN SCHEMA %s TO %s", schemaPrivileges, database.Schema, name))
+		log.Info(fmt.Sprintf("Granting %s to %s", schemaPrivileges, name))
+		_, err = db.Exec(fmt.Sprintf("GRANT %s_%s TO %s", database.Name, schemaPrivileges, name))
 		if err != nil {
 			return fmt.Errorf("grant access privileges '%s' on schema '%s': %w", schemaPrivileges, database.Schema, err)
 		}

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -98,7 +98,7 @@ func TestRole_staticRoles(t *testing.T) {
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
-		Database: "",
+		Database: "postgres",
 		Password: "",
 	})
 	if err != nil {
@@ -201,7 +201,7 @@ func TestRole_priviliges_databaseNameAndSchemaDiffers(t *testing.T) {
 	iamCreatorRootDB, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
-		Database: "",
+		Database: "postgres",
 		Password: "",
 	})
 	if err != nil {
@@ -269,7 +269,7 @@ func TestRole_priviliges(t *testing.T) {
 	iamCreatorRootDB, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
-		Database: "",
+		Database: "postgres",
 		Password: "",
 	})
 	if err != nil {
@@ -386,11 +386,12 @@ func TestRole_priviliges(t *testing.T) {
 	}
 	_, err = userDB.Query(fmt.Sprintf("INSERT INTO %s.films VALUES('new title')", serviceUser2))
 	if err != nil {
-		t.Fatalf("could not insert into %s.films table when it should not", serviceUser2)
+		t.Fatalf("could not insert into %s.films table: %v", serviceUser2, err)
 	}
 }
 
 func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host, service string) {
+	t.Helper()
 	err := postgres.Database(log, database, host, postgres.Credentials{
 		Name:     service,
 		Password: "",


### PR DESCRIPTION
This change introduces two additional service roles with read and readwrite
priviledges on the database.

When granting read/readwrite access to a database users are granted these roles.

This fixes the bug where the iam_creator role was not able to grant access on
objects not created by it.