### PR TITLE
Add all databases field

### DIFF
--- a/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
+++ b/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
@@ -175,7 +175,6 @@ spec:
                 required:
                 - host
                 - reason
-                - schema
                 type: object
               type: array
             write:
@@ -317,7 +316,6 @@ spec:
                 required:
                 - host
                 - reason
-                - schema
                 type: object
               type: array
           required:

--- a/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
+++ b/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
@@ -39,6 +39,8 @@ spec:
             read:
               items:
                 properties:
+                  allDatabases:
+                    type: boolean
                   database:
                     description: PasswordVar represents an
                     properties:
@@ -171,6 +173,7 @@ spec:
                     format: date-time
                     type: string
                 required:
+                - allDatabases
                 - database
                 - host
                 - reason
@@ -180,6 +183,8 @@ spec:
             write:
               items:
                 properties:
+                  allDatabases:
+                    type: boolean
                   database:
                     description: PasswordVar represents an
                     properties:
@@ -312,6 +317,7 @@ spec:
                     format: date-time
                     type: string
                 required:
+                - allDatabases
                 - database
                 - host
                 - reason

--- a/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
+++ b/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
@@ -173,8 +173,6 @@ spec:
                     format: date-time
                     type: string
                 required:
-                - allDatabases
-                - database
                 - host
                 - reason
                 - schema
@@ -317,8 +315,6 @@ spec:
                     format: date-time
                     type: string
                 required:
-                - allDatabases
-                - database
                 - host
                 - reason
                 - schema

--- a/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
+++ b/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
@@ -21,11 +21,13 @@ type PostgreSQLUserSpec struct {
 }
 
 type AccessSpec struct {
-	Host         ResourceVar `json:"host"`
-	AllDatabases bool        `json:"allDatabases"`
-	Database     ResourceVar `json:"database"`
-	Schema       ResourceVar `json:"schema"`
-	Reason       string      `json:"reason"`
+	Host ResourceVar `json:"host"`
+	// +optional
+	AllDatabases bool `json:"allDatabases"`
+	// +optional
+	Database ResourceVar `json:"database"`
+	Schema   ResourceVar `json:"schema"`
+	Reason   string      `json:"reason"`
 	// +optional
 	Start metav1.Time `json:"start"`
 	// +optional

--- a/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
+++ b/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
@@ -21,10 +21,11 @@ type PostgreSQLUserSpec struct {
 }
 
 type AccessSpec struct {
-	Host     ResourceVar `json:"host"`
-	Database ResourceVar `json:"database"`
-	Schema   ResourceVar `json:"schema"`
-	Reason   string      `json:"reason"`
+	Host         ResourceVar `json:"host"`
+	AllDatabases bool        `json:"allDatabases"`
+	Database     ResourceVar `json:"database"`
+	Schema       ResourceVar `json:"schema"`
+	Reason       string      `json:"reason"`
 	// +optional
 	Start metav1.Time `json:"start"`
 	// +optional

--- a/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
+++ b/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
@@ -26,8 +26,9 @@ type AccessSpec struct {
 	AllDatabases bool `json:"allDatabases"`
 	// +optional
 	Database ResourceVar `json:"database"`
-	Schema   ResourceVar `json:"schema"`
-	Reason   string      `json:"reason"`
+	// +optional
+	Schema ResourceVar `json:"schema"`
+	Reason string      `json:"reason"`
 	// +optional
 	Start metav1.Time `json:"start"`
 	// +optional

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -437,7 +437,7 @@ func (err *AccessError) Error() string {
 	if host == "" && err.Access.Host.ValueFrom.ConfigMapKeyRef != nil {
 		host = fmt.Sprintf("from config map '%s' key '%s'", err.Access.Host.ValueFrom.ConfigMapKeyRef.Name, err.Access.Host.ValueFrom.ConfigMapKeyRef.Key)
 	}
-	return fmt.Sprintf("access to host %s: %v: access data: %+v", host, err.Err, err.Access)
+	return fmt.Sprintf("access to host %s: %v", host, err.Err)
 }
 
 func (err *AccessError) Unwrap() error {

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -396,7 +396,9 @@ func (r *ReconcilePostgreSQLUser) groupAllDatabasesByHost(hosts HostAccess, host
 	var errs error
 	for _, databaseResource := range databases {
 		database := databaseResource.Spec.Name
-		schema := databaseResource.Spec.Name // FIXME: This will not work when schemas differ from database names
+		// this limits the `allDatabases` field to only work grant access in a
+		// schema named after the database
+		schema := databaseResource.Spec.Name
 		databaseHost, err := r.resourceResolver(r.client, databaseResource.Spec.Host, namespace)
 		if err != nil {
 			errs = multierr.Append(errs, fmt.Errorf("resolve database '%s' host name: %w", databaseResource.Spec.Name, err))

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -137,25 +137,25 @@ func TestReconcilePostgreSQLUser_groupAccesses(t *testing.T) {
 		{
 			name: "single read and single host",
 			reads: []lunarwayv1alpha1.AccessSpec{
-				accessSpec("localhost:5432", "I'am a developer"),
+				accessSpec("localhost:5432", "I am a developer"),
 			},
 			writes: nil,
 			output: HostAccess{
 				"localhost:5432/database": []ReadWriteAccess{
-					access("localhost:5432", "database", postgres.PrivilegeRead, "I'am a developer"),
+					access("localhost:5432", "database", postgres.PrivilegeRead, "I am a developer"),
 				},
 			},
 		},
 		{
 			name: "multiple reads and single host",
 			reads: []lunarwayv1alpha1.AccessSpec{
-				accessSpec("localhost:5432", "I'am a developer"),
+				accessSpec("localhost:5432", "I am a developer"),
 				accessSpec("localhost:5432", "I really am a developer"),
 			},
 			writes: nil,
 			output: HostAccess{
 				"localhost:5432/database": []ReadWriteAccess{
-					access("localhost:5432", "database", postgres.PrivilegeRead, "I'am a developer"),
+					access("localhost:5432", "database", postgres.PrivilegeRead, "I am a developer"),
 					access("localhost:5432", "database", postgres.PrivilegeRead, "I really am a developer"),
 				},
 			},
@@ -163,13 +163,13 @@ func TestReconcilePostgreSQLUser_groupAccesses(t *testing.T) {
 		{
 			name: "multiple reads and multiple hosts",
 			reads: []lunarwayv1alpha1.AccessSpec{
-				accessSpec("host1:5432", "I'am a developer"),
+				accessSpec("host1:5432", "I am a developer"),
 				accessSpec("host2:5432", "I really am a developer"),
 			},
 			writes: nil,
 			output: HostAccess{
 				"host1:5432/database": []ReadWriteAccess{
-					access("host1:5432", "database", postgres.PrivilegeRead, "I'am a developer"),
+					access("host1:5432", "database", postgres.PrivilegeRead, "I am a developer"),
 				},
 				"host2:5432/database": []ReadWriteAccess{
 					access("host2:5432", "database", postgres.PrivilegeRead, "I really am a developer"),
@@ -179,7 +179,7 @@ func TestReconcilePostgreSQLUser_groupAccesses(t *testing.T) {
 		{
 			name: "multiple reads and writes and multiple hosts",
 			reads: []lunarwayv1alpha1.AccessSpec{
-				accessSpec("host1:5432", "I'am a developer"),
+				accessSpec("host1:5432", "I am a developer"),
 				accessSpec("host2:5432", "I really am a developer"),
 			},
 			writes: []lunarwayv1alpha1.AccessSpec{
@@ -188,7 +188,7 @@ func TestReconcilePostgreSQLUser_groupAccesses(t *testing.T) {
 			},
 			output: HostAccess{
 				"host1:5432/database": []ReadWriteAccess{
-					access("host1:5432", "database", postgres.PrivilegeRead, "I'am a developer"),
+					access("host1:5432", "database", postgres.PrivilegeRead, "I am a developer"),
 					access("host1:5432", "database", postgres.PrivilegeWrite, "I'am a writing developer"),
 				},
 				"host2:5432/database": []ReadWriteAccess{
@@ -203,6 +203,277 @@ func TestReconcilePostgreSQLUser_groupAccesses(t *testing.T) {
 			r := ReconcilePostgreSQLUser{
 				resourceResolver: func(client client.Client, r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 					return r.Value, nil
+				},
+				allDatabases: func(client client.Client, namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
+					t.Fatalf("allDatabases was not expected to be used")
+					return nil, nil
+				},
+			}
+
+			output, err := r.groupAccesses("namespace", tc.reads, tc.writes)
+
+			assert.NoError(t, err, "unexpected output error")
+			assert.Equal(t, tc.output, output, "output map not as expected")
+		})
+	}
+}
+
+func TestReconcilePostgreSQLUser_groupAccesses_WithAllDatabases(t *testing.T) {
+	database := func(host, name string) lunarwayv1alpha1.PostgreSQLDatabase {
+		return lunarwayv1alpha1.PostgreSQLDatabase{
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Name: name,
+				Host: lunarwayv1alpha1.ResourceVar{
+					Value: host,
+				},
+			},
+		}
+	}
+	spec := func(host, reason string) lunarwayv1alpha1.AccessSpec {
+		return lunarwayv1alpha1.AccessSpec{
+			Host: lunarwayv1alpha1.ResourceVar{
+				Value: host,
+			},
+			AllDatabases: true,
+			Reason:       reason,
+		}
+	}
+	access := func(host, database string, privilige postgres.Privilege, reason string) ReadWriteAccess {
+		return ReadWriteAccess{
+			Host: host,
+			Database: postgres.DatabaseSchema{
+				Name:       database,
+				Schema:     database,
+				Privileges: privilige,
+			},
+			Access: spec(host, reason),
+		}
+	}
+	tt := []struct {
+		name      string
+		databases []lunarwayv1alpha1.PostgreSQLDatabase
+		reads     []lunarwayv1alpha1.AccessSpec
+		writes    []lunarwayv1alpha1.AccessSpec
+		output    HostAccess
+	}{
+		{
+			name: "single allDatabases read",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				database("host1:5432", "database"),
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: nil,
+			output: HostAccess{
+				"host1:5432/database": []ReadWriteAccess{
+					access("host1:5432", "database", postgres.PrivilegeRead, "I am a developer"),
+				},
+			},
+		},
+		{
+			name: "multiple allDatabases read and write on same host",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				database("host1:5432", "database1"),
+				database("host1:5432", "database2"),
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a writing developer"),
+			},
+			output: HostAccess{
+				"host1:5432/database1": []ReadWriteAccess{
+					access("host1:5432", "database1", postgres.PrivilegeRead, "I am a developer"),
+					access("host1:5432", "database1", postgres.PrivilegeWrite, "I am a writing developer"),
+				},
+				"host1:5432/database2": []ReadWriteAccess{
+					access("host1:5432", "database2", postgres.PrivilegeRead, "I am a developer"),
+					access("host1:5432", "database2", postgres.PrivilegeWrite, "I am a writing developer"),
+				},
+			},
+		},
+		{
+			name: "multiple allDatabases read and write on different hosts",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				database("host1:5432", "database1"),
+				database("host2:5432", "database2"),
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: []lunarwayv1alpha1.AccessSpec{
+				spec("host2:5432", "I am a writing developer"),
+			},
+			output: HostAccess{
+				"host1:5432/database1": []ReadWriteAccess{
+					access("host1:5432", "database1", postgres.PrivilegeRead, "I am a developer"),
+				},
+				"host2:5432/database2": []ReadWriteAccess{
+					access("host2:5432", "database2", postgres.PrivilegeWrite, "I am a writing developer"),
+				},
+			},
+		},
+		{
+			name: "multiple allDatabases read and write on different hosts with multiple databases",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				database("host1:5432", "database1"),
+				database("host1:5432", "database2"),
+				database("host2:5432", "database3"),
+				database("host2:5432", "database4"),
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: []lunarwayv1alpha1.AccessSpec{
+				spec("host2:5432", "I am a writing developer"),
+			},
+			output: HostAccess{
+				"host1:5432/database1": []ReadWriteAccess{
+					access("host1:5432", "database1", postgres.PrivilegeRead, "I am a developer"),
+				},
+				"host1:5432/database2": []ReadWriteAccess{
+					access("host1:5432", "database2", postgres.PrivilegeRead, "I am a developer"),
+				},
+				"host2:5432/database3": []ReadWriteAccess{
+					access("host2:5432", "database3", postgres.PrivilegeWrite, "I am a writing developer"),
+				},
+				"host2:5432/database4": []ReadWriteAccess{
+					access("host2:5432", "database4", postgres.PrivilegeWrite, "I am a writing developer"),
+				},
+			},
+		},
+		{
+			name: "read with allDatabases and unused hosts",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				database("host1:5432", "database1"),
+				database("host2:5432", "database2"),
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: nil,
+			output: HostAccess{
+				"host1:5432/database1": []ReadWriteAccess{
+					access("host1:5432", "database1", postgres.PrivilegeRead, "I am a developer"),
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			r := ReconcilePostgreSQLUser{
+				resourceResolver: func(client client.Client, r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
+					return r.Value, nil
+				},
+				allDatabases: func(client client.Client, namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
+					return tc.databases, nil
+				},
+			}
+
+			output, err := r.groupAccesses("namespace", tc.reads, tc.writes)
+
+			assert.NoError(t, err, "unexpected output error")
+			assert.Equal(t, tc.output, output, "output map not as expected")
+		})
+	}
+}
+
+func TestReconcilePostgreSQLUser_groupAccesses_mixedSpecs(t *testing.T) {
+	database := func(host, name string) lunarwayv1alpha1.PostgreSQLDatabase {
+		return lunarwayv1alpha1.PostgreSQLDatabase{
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Name: name,
+				Host: lunarwayv1alpha1.ResourceVar{
+					Value: host,
+				},
+			},
+		}
+	}
+	allDatabasesSpec := func(host, reason string) lunarwayv1alpha1.AccessSpec {
+		return lunarwayv1alpha1.AccessSpec{
+			Host: lunarwayv1alpha1.ResourceVar{
+				Value: host,
+			},
+			AllDatabases: true,
+			Reason:       reason,
+		}
+	}
+	singleDatabaseSpec := func(host, database, reason string) lunarwayv1alpha1.AccessSpec {
+		return lunarwayv1alpha1.AccessSpec{
+			Host: lunarwayv1alpha1.ResourceVar{
+				Value: host,
+			},
+			Database: lunarwayv1alpha1.ResourceVar{
+				Value: database,
+			},
+			Schema: lunarwayv1alpha1.ResourceVar{
+				Value: database,
+			},
+			Reason: reason,
+		}
+	}
+	allDatabasesAccess := func(host, database string, privilige postgres.Privilege, reason string) ReadWriteAccess {
+		return ReadWriteAccess{
+			Host: host,
+			Database: postgres.DatabaseSchema{
+				Name:       database,
+				Schema:     database,
+				Privileges: privilige,
+			},
+			Access: allDatabasesSpec(host, reason),
+		}
+	}
+	singleDatabaseAccess := func(host, database string, privilige postgres.Privilege, reason string) ReadWriteAccess {
+		return ReadWriteAccess{
+			Host: host,
+			Database: postgres.DatabaseSchema{
+				Name:       database,
+				Schema:     database,
+				Privileges: privilige,
+			},
+			Access: singleDatabaseSpec(host, database, reason),
+		}
+	}
+	tt := []struct {
+		name      string
+		databases []lunarwayv1alpha1.PostgreSQLDatabase
+		reads     []lunarwayv1alpha1.AccessSpec
+		writes    []lunarwayv1alpha1.AccessSpec
+		output    HostAccess
+	}{
+		{
+			name: "single write and allDatabases read on same host",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				database("host1:5432", "database1"),
+				database("host1:5432", "database2"),
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				allDatabasesSpec("host1:5432", "I am a developer"),
+			},
+			writes: []lunarwayv1alpha1.AccessSpec{
+				singleDatabaseSpec("host1:5432", "database2", "I am a writing developer"),
+			},
+			output: HostAccess{
+				"host1:5432/database1": []ReadWriteAccess{
+					allDatabasesAccess("host1:5432", "database1", postgres.PrivilegeRead, "I am a developer"),
+				},
+				"host1:5432/database2": []ReadWriteAccess{
+					allDatabasesAccess("host1:5432", "database2", postgres.PrivilegeRead, "I am a developer"),
+					singleDatabaseAccess("host1:5432", "database2", postgres.PrivilegeWrite, "I am a writing developer"),
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			r := ReconcilePostgreSQLUser{
+				resourceResolver: func(client client.Client, r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
+					return r.Value, nil
+				},
+				allDatabases: func(client client.Client, namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
+					return tc.databases, nil
 				},
 			}
 
@@ -220,7 +491,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_errors(t *testing.T) {
 			Host: lunarwayv1alpha1.ResourceVar{
 				Value: "host1:5432",
 			},
-			Reason: "I'am a developer",
+			Reason: "I am a developer",
 		},
 		{
 			Host: lunarwayv1alpha1.ResourceVar{

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -629,7 +629,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_errors(t *testing.T) {
 			Reason: "I'm not a developer",
 		},
 	}
-	expectedError := "access to host host1:5432: no value; access to host from secret 'secret' key 'key': no value; access to host from config map 'configmap' key 'key': no value"
+	expectedError := "resolve host: access to host host1:5432: no value; resolve host: access to host from secret 'secret' key 'key': no value; resolve host: access to host from config map 'configmap' key 'key': no value"
 
 	logger := test.NewLogger(t)
 	r := ReconcilePostgreSQLUser{

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -58,3 +58,7 @@ func ConfigMapValue(client client.Client, namespacedName types.NamespacedName, k
 	}
 	return string(data), nil
 }
+
+func PostgreSQLDatabases(client client.Client, namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
+	return nil, nil
+}

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -59,6 +59,11 @@ func ConfigMapValue(client client.Client, namespacedName types.NamespacedName, k
 	return string(data), nil
 }
 
-func PostgreSQLDatabases(client client.Client, namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
-	return nil, nil
+func PostgreSQLDatabases(c client.Client, namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
+	var databases lunarwayv1alpha1.PostgreSQLDatabaseList
+	err := c.List(context.TODO(), &databases, client.InNamespace(namespace))
+	if err != nil {
+		return nil, fmt.Errorf("get databases in namespace: %w", err)
+	}
+	return databases.Items, nil
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -67,6 +67,17 @@ type DatabaseSchema struct {
 	Privileges Privilege
 }
 
+func (p Privilege) String() string {
+	switch p {
+	case PrivilegeRead:
+		return "read"
+	case PrivilegeWrite:
+		return "write"
+	default:
+		return "unknown"
+	}
+}
+
 func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []DatabaseSchema) error {
 	log.Info(fmt.Sprintf("Creating role %s", name))
 	query := fmt.Sprintf("CREATE ROLE %s WITH LOGIN", name)

--- a/test/log.go
+++ b/test/log.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -11,6 +12,10 @@ import (
 func SetLogger(t *testing.T) *log.DelegatingLogger {
 	log.SetLogger(zap.LoggerTo(&logger{t: t}, true))
 	return log.Log
+}
+
+func NewLogger(t *testing.T) logr.Logger {
+	return zap.LoggerTo(&logger{t: t}, true)
 }
 
 var _ io.Writer = &logger{}


### PR DESCRIPTION
This change set implements an `allDatabases` field on `PostgreSQLUser` resources.
Specifically on the `AccessSpec` structs to support it on read and write requests.

The functionality is feature gated by two CLI flags, `all-databases-enabled-read` and `all-databases-enabled-write`.

### Current limitations

- [ ] New `PostgreSQLDatabase` resources does not trigger an update to granted user rights (restarts of the controller does however)
- [ ] The granted schema follows the name of the database, ie. `allDatabases` does not grant access to `public` if the database name is something else.
- [ ] There is generally still no clean up of roles when databases and users are removed.

### Other considerations

Kubebuilder does not currently support `oneOf` validation of fields so `allDatabases`, `database` and `schema` needs to be optional. This leads to the possibility of allowing incomplete specifications like this. Notice that neither `allDatabases` nor `database` is set.

```yaml
apiVersion: lunarway.com/v1alpha1
kind: PostgreSQLUser
metadata:
  name: bso
spec:
  name: bso
  read:
    - host:
        value: postgresql:5432
      reason: I am a developer testing postgresql-controller
```

In my opinion we can get this merged and work on the two limitations in a future PR to keep the change set small and focused. What do you say?