### PR TITLE
Remove base64 decoding of secret values

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -39,11 +38,7 @@ func SecretValue(client client.Client, namespacedName types.NamespacedName, key 
 	if !ok {
 		return "", errors.New("unknown secret key")
 	}
-	password, err := base64.StdEncoding.DecodeString(string(secretData))
-	if err != nil {
-		return "", fmt.Errorf("base64 decode secret %s/%s key '%s': %w", namespacedName.Namespace, namespacedName.Name, key, err)
-	}
-	return string(password), nil
+	return string(secretData), nil
 }
 
 func ConfigMapValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -52,11 +52,11 @@ func TestResourceValue(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string][]byte{
-						"key": []byte("dGVzdA=="),
+						"key": []byte("password"),
 					},
 				},
 			},
-			output: "test",
+			output: "password",
 			err:    nil,
 		},
 		{
@@ -128,21 +128,10 @@ func TestSecretValue(t *testing.T) {
 			namespace:  "test",
 			key:        "test",
 			data: map[string][]byte{
-				"test": []byte("dGVzdA=="),
+				"test": []byte("password"),
 			},
-			output: "test",
+			output: "password",
 			err:    nil,
-		},
-		{
-			name:       "illegal base64",
-			secretName: "test",
-			namespace:  "test",
-			key:        "test",
-			data: map[string][]byte{
-				"test": []byte("dGVZdA"),
-			},
-			output: "",
-			err:    errors.New("base64 decode secret test/test key 'test': illegal base64 data at input byte 4"),
 		},
 		{
 			name:       "unknown key",
@@ -150,7 +139,7 @@ func TestSecretValue(t *testing.T) {
 			namespace:  "test",
 			key:        "anotherkey",
 			data: map[string][]byte{
-				"test": []byte("dGVZdA"),
+				"test": []byte("password"),
 			},
 			output: "",
 			err:    errors.New("unknown secret key"),


### PR DESCRIPTION
This is handled by client-go so we should not do it.