### PR TITLE
Add behavioural errors to database controller

### DIFF
--- a/deploy/crds/lunarway.com_postgresqldatabases_crd.yaml
+++ b/deploy/crds/lunarway.com_postgresqldatabases_crd.yaml
@@ -16,6 +16,10 @@ spec:
     description: Timestamp of last status update
     name: Updated
     type: date
+  - JSONPath: .status.host
+    description: Database host
+    name: Host
+    type: string
   group: lunarway.com
   names:
     kind: PostgreSQLDatabase
@@ -138,6 +142,8 @@ spec:
           description: PostgreSQLDatabaseStatus defines the observed state of PostgreSQLDatabase
           properties:
             error:
+              type: string
+            host:
               type: string
             phase:
               description: PostgreSQLDatabasePhase represents the current phase of

--- a/pkg/apis/lunarway/v1alpha1/postgresqldatabase_types.go
+++ b/pkg/apis/lunarway/v1alpha1/postgresqldatabase_types.go
@@ -33,6 +33,7 @@ const (
 type PostgreSQLDatabaseStatus struct {
 	PhaseUpdated metav1.Time             `json:"phaseUpdated"`
 	Phase        PostgreSQLDatabasePhase `json:"phase"`
+	Host         string                  `json:"host,omitempty"`
 	Error        string                  `json:"error,omitempty"`
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
@@ -47,6 +48,7 @@ type PostgreSQLDatabaseStatus struct {
 // +kubebuilder:printcolumn:name="Database",type="string",JSONPath=".spec.name",description="Database name"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Database status"
 // +kubebuilder:printcolumn:name="Updated",type="date",JSONPath=".status.phaseUpdated",description="Timestamp of last status update"
+// +kubebuilder:printcolumn:name="Host",type="string",JSONPath=".status.host",description="Database host"
 type PostgreSQLDatabase struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/lunarway/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/lunarway/v1alpha1/zz_generated.openapi.go
@@ -117,6 +117,12 @@ func schema_pkg_apis_lunarway_v1alpha1_PostgreSQLDatabaseStatus(ref common.Refer
 							Format: "",
 						},
 					},
+					"host": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"error": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -187,7 +187,6 @@ func (s *status) Persist(err error) {
 	if err != nil {
 		log.Error(err, "failed to set status of database", "status", s)
 	}
-	return
 }
 
 // update updates database reference based on its values and returns whether any

--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -224,6 +224,9 @@ func stopRequeueOnInvalid(log logr.Logger, err error) error {
 	if !ctlerrors.IsInvalid(err) {
 		return err
 	}
+	if ctlerrors.IsTemporary(err) {
+		return err
+	}
 	log.Error(err, "Dropping resources from queue as it is invalid")
 	return nil
 }

--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller_test.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller_test.go
@@ -7,36 +7,36 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/pkg/apis/lunarway/v1alpha1"
+	ctlerrors "go.lunarway.com/postgresql-controller/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestReconcilePostgreSQLDatabase_setStatus(t *testing.T) {
+func TestStatus_update(t *testing.T) {
 	before := metav1.Time{
 		Time: time.Date(2019, time.December, 18, 17, 7, 3, 0, time.UTC),
 	}
 	now := metav1.Time{
 		Time: time.Date(2019, time.December, 18, 18, 7, 3, 0, time.UTC),
 	}
-	nowFunc := func() metav1.Time {
-		return now
-	}
 	tt := []struct {
 		name    string
-		before  *lunarwayv1alpha1.PostgreSQLDatabase
-		status  lunarwayv1alpha1.PostgreSQLDatabasePhase
+		status  status
 		err     error
 		changes bool
 		after   *lunarwayv1alpha1.PostgreSQLDatabase
 	}{
 		{
 			name: "new status",
-			before: &lunarwayv1alpha1.PostgreSQLDatabase{
-				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
-					Phase: "",
+			status: status{
+				database: &lunarwayv1alpha1.PostgreSQLDatabase{
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase: "",
+					},
 				},
 			},
-			status:  lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
-			err:     errors.New("some validation error"),
+			err: &ctlerrors.Invalid{
+				Err: errors.New("some validation error"),
+			},
 			changes: true,
 			after: &lunarwayv1alpha1.PostgreSQLDatabase{
 				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
@@ -48,19 +48,20 @@ func TestReconcilePostgreSQLDatabase_setStatus(t *testing.T) {
 		},
 		{
 			name: "same status and error",
-			before: &lunarwayv1alpha1.PostgreSQLDatabase{
-				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
-					Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
-					PhaseUpdated: before,
-					Error:        "some validation error",
+			status: status{
+				database: &lunarwayv1alpha1.PostgreSQLDatabase{
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseFailed,
+						PhaseUpdated: before,
+						Error:        "some validation error",
+					},
 				},
 			},
-			status:  lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
 			err:     errors.New("some validation error"),
 			changes: false,
 			after: &lunarwayv1alpha1.PostgreSQLDatabase{
 				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
-					Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
+					Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseFailed,
 					PhaseUpdated: before,
 					Error:        "some validation error",
 				},
@@ -68,15 +69,18 @@ func TestReconcilePostgreSQLDatabase_setStatus(t *testing.T) {
 		},
 		{
 			name: "same status and different error",
-			before: &lunarwayv1alpha1.PostgreSQLDatabase{
-				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
-					Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
-					PhaseUpdated: before,
-					Error:        "some validation error",
+			status: status{
+				database: &lunarwayv1alpha1.PostgreSQLDatabase{
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
+						PhaseUpdated: before,
+						Error:        "some validation error",
+					},
 				},
 			},
-			status:  lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
-			err:     errors.New("some new validation error"),
+			err: &ctlerrors.Invalid{
+				Err: errors.New("some new validation error"),
+			},
 			changes: true,
 			after: &lunarwayv1alpha1.PostgreSQLDatabase{
 				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
@@ -88,14 +92,15 @@ func TestReconcilePostgreSQLDatabase_setStatus(t *testing.T) {
 		},
 		{
 			name: "new status and no error",
-			before: &lunarwayv1alpha1.PostgreSQLDatabase{
-				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
-					Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
-					PhaseUpdated: before,
-					Error:        "some validation error",
+			status: status{
+				database: &lunarwayv1alpha1.PostgreSQLDatabase{
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
+						PhaseUpdated: before,
+						Error:        "some validation error",
+					},
 				},
 			},
-			status:  lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
 			err:     nil,
 			changes: true,
 			after: &lunarwayv1alpha1.PostgreSQLDatabase{
@@ -106,12 +111,39 @@ func TestReconcilePostgreSQLDatabase_setStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "host name changed",
+			status: status{
+				database: &lunarwayv1alpha1.PostgreSQLDatabase{
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseFailed,
+						PhaseUpdated: before,
+						Error:        "unknown host",
+						Host:         "localhost:1234",
+					},
+				},
+				host: "localhost:5432",
+			},
+			err:     nil,
+			changes: true,
+			after: &lunarwayv1alpha1.PostgreSQLDatabase{
+				Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+					Phase:        lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+					PhaseUpdated: now,
+					Error:        "",
+					Host:         "localhost:5432",
+				},
+			},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			changes := updateStatus(nowFunc, tc.before, tc.status, tc.err)
+			tc.status.now = func() metav1.Time {
+				return now
+			}
+			changes := tc.status.update(tc.err)
 			assert.Equal(t, changes, tc.changes, "change indication not as expected")
-			assert.Equal(t, tc.after, tc.before, "database status not as expected")
+			assert.Equal(t, tc.after, tc.status.database, "database status not as expected")
 		})
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -42,5 +42,45 @@ func IsInvalid(err error) bool {
 	var invalidErr interface {
 		Invalid() bool
 	}
-	return errors.As(err, &invalidErr)
+	return errors.As(err, &invalidErr) && invalidErr.Invalid()
+}
+
+// Temporary is a behavioural error type indicating an temporary error
+// condition. Use this to indicate to users that an error occoured but the
+// controller will keep trying to recover.
+//
+// Examples of such errors are unknown config map names or unreachable hosts.
+type Temporary struct {
+	Err error
+}
+
+func (i *Temporary) Error() string {
+	return fmt.Sprintf("%v", i.Err)
+}
+
+func (i *Temporary) Temporary() bool {
+	return true
+}
+
+func (i *Temporary) Unwrap() error {
+	return i.Err
+}
+
+// NewTemporary returns an Temporary error with err inside. If err is nil, nil is
+// returned.
+func NewTemporary(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &Temporary{
+		Err: err,
+	}
+}
+
+// IsTemporary returns whether err is an Temporary error.
+func IsTemporary(err error) bool {
+	var temporaryError interface {
+		Temporary() bool
+	}
+	return errors.As(err, &temporaryError) && temporaryError.Temporary()
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,46 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Invalid is a behavioural error type indicating an invalid value or
+// configuration. Use this to indicate to users that they need to change some
+// configuration in order to proceed.
+//
+// Examples of such errors are unknown config map keys and wrong host names.
+type Invalid struct {
+	Err error
+}
+
+func (i *Invalid) Error() string {
+	return fmt.Sprintf("%v", i.Err)
+}
+
+func (i *Invalid) Invalid() bool {
+	return true
+}
+
+func (i *Invalid) Unwrap() error {
+	return i.Err
+}
+
+// NewInvalid returns an Invalid error with err inside. If err is nil, nil is
+// returned.
+func NewInvalid(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &Invalid{
+		Err: err,
+	}
+}
+
+// IsInvalid returns whether err is an Invalid error.
+func IsInvalid(err error) bool {
+	var invalidErr interface {
+		Invalid() bool
+	}
+	return errors.As(err, &invalidErr)
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -9,7 +9,7 @@ import (
 // configuration. Use this to indicate to users that they need to change some
 // configuration in order to proceed.
 //
-// Examples of such errors are unknown config map keys and wrong host names.
+// Examples of such errors are unknown config map names or empty keys.
 type Invalid struct {
 	Err error
 }

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -6,9 +6,17 @@ import (
 	"fmt"
 
 	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/pkg/apis/lunarway/v1alpha1"
+	ctrerrors "go.lunarway.com/postgresql-controller/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	errNoValue    = ctrerrors.NewInvalid(errors.New("no value"))
+	errNotFound   = ctrerrors.NewInvalid(errors.New("not found"))
+	errUnknownKey = ctrerrors.NewInvalid(errors.New("unknown key"))
 )
 
 // ResourceValue returns the value of a ResourceVar in a specific namespace.
@@ -18,38 +26,62 @@ func ResourceValue(client client.Client, resource lunarwayv1alpha1.ResourceVar, 
 	}
 
 	if resource.ValueFrom != nil && resource.ValueFrom.SecretKeyRef != nil && resource.ValueFrom.SecretKeyRef.Key != "" {
-		return SecretValue(client, types.NamespacedName{Name: resource.ValueFrom.SecretKeyRef.Name, Namespace: namespace}, resource.ValueFrom.SecretKeyRef.Key)
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      resource.ValueFrom.SecretKeyRef.Name,
+		}
+		key := resource.ValueFrom.SecretKeyRef.Key
+		v, err := SecretValue(client, namespacedName, key)
+		if err != nil {
+			return "", fmt.Errorf("secret %s key %s: %w", namespacedName, key, err)
+		}
+		return v, nil
 	}
 
 	if resource.ValueFrom != nil && resource.ValueFrom.ConfigMapKeyRef != nil && resource.ValueFrom.ConfigMapKeyRef.Key != "" {
-		return ConfigMapValue(client, types.NamespacedName{Name: resource.ValueFrom.ConfigMapKeyRef.Name, Namespace: namespace}, resource.ValueFrom.ConfigMapKeyRef.Key)
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      resource.ValueFrom.ConfigMapKeyRef.Name,
+		}
+		key := resource.ValueFrom.ConfigMapKeyRef.Key
+		v, err := ConfigMapValue(client, namespacedName, key)
+		if err != nil {
+			return "", fmt.Errorf("config map %s key %s: %w", namespacedName, key, err)
+		}
+		return v, nil
 	}
 
-	return "", fmt.Errorf("no value")
+	return "", errNoValue
 }
 
 func SecretValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {
 	secret := &corev1.Secret{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, secret)
+	err := client.Get(context.TODO(), namespacedName, secret)
 	if err != nil {
-		return "", fmt.Errorf("get secret %s/%s: %w", namespacedName.Namespace, namespacedName.Name, err)
+		if apierrors.IsNotFound(err) {
+			return "", errNotFound
+		}
+		return "", err
 	}
 	secretData, ok := secret.Data[key]
 	if !ok {
-		return "", errors.New("unknown secret key")
+		return "", errUnknownKey
 	}
 	return string(secretData), nil
 }
 
 func ConfigMapValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {
 	configMap := &corev1.ConfigMap{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, configMap)
+	err := client.Get(context.TODO(), namespacedName, configMap)
 	if err != nil {
-		return "", fmt.Errorf("get config map %s/%s: %w", namespacedName.Namespace, namespacedName.Name, err)
+		if apierrors.IsNotFound(err) {
+			return "", errNotFound
+		}
+		return "", err
 	}
 	data, ok := configMap.Data[key]
 	if !ok {
-		return "", errors.New("unknown config map key")
+		return "", errUnknownKey
 	}
 	return string(data), nil
 }

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -15,8 +15,8 @@ import (
 
 var (
 	errNoValue    = ctrerrors.NewInvalid(errors.New("no value"))
-	errNotFound   = ctrerrors.NewInvalid(errors.New("not found"))
-	errUnknownKey = ctrerrors.NewInvalid(errors.New("unknown key"))
+	errNotFound   = ctrerrors.NewTemporary(ctrerrors.NewInvalid(errors.New("not found")))
+	errUnknownKey = ctrerrors.NewTemporary(ctrerrors.NewInvalid(errors.New("unknown key")))
 )
 
 // ResourceValue returns the value of a ResourceVar in a specific namespace.

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -35,6 +35,16 @@ func TestResourceValue(t *testing.T) {
 			err:       nil,
 		},
 		{
+			name: "empty raw value resource",
+			resource: lunarwayv1alpha1.ResourceVar{
+				Value: "",
+			},
+			namespace: "default",
+			objs:      nil,
+			output:    "",
+			err:       errors.New("no value"),
+		},
+		{
 			name: "secret value resource",
 			resource: lunarwayv1alpha1.ResourceVar{
 				ValueFrom: &lunarwayv1alpha1.ResourceVarSource{
@@ -142,7 +152,7 @@ func TestSecretValue(t *testing.T) {
 				"test": []byte("password"),
 			},
 			output: "",
-			err:    errors.New("unknown secret key"),
+			err:    errors.New("unknown key"),
 		},
 	}
 	for _, tc := range tt {
@@ -209,7 +219,7 @@ func TestConfigMapValue(t *testing.T) {
 				"test": "test",
 			},
 			output: "",
-			err:    errors.New("unknown config map key"),
+			err:    errors.New("unknown key"),
 		},
 	}
 	for _, tc := range tt {


### PR DESCRIPTION
This change adds a new error handling flow based on behavioural errors.

A new `errors` package with two error types `Invalid` and `Temporary` are introduced used to indicate to the user that some configuration is invalid and the controller cannot proceed with a resource or that it should retry later on due temporary conditions like a missing config map or host.

The controller is changed to detect the errors and set the phase accordingly.

Further a `host` column is added to the list output of `PostgreSQLDatabase` resources.

```
$ kubectl get postgresqldatabases.lunarway.com
NAME                  DATABASE   STATUS    UPDATED   HOST
product-db            product    Running   3m28s     postgresql:5432
product-db-bad-host   product    Invalid   26m
```
