### PR TITLE
Add short names for custom resources

### DIFF
--- a/deploy/crds/lunarway.com_postgresqldatabases_crd.yaml
+++ b/deploy/crds/lunarway.com_postgresqldatabases_crd.yaml
@@ -21,6 +21,8 @@ spec:
     kind: PostgreSQLDatabase
     listKind: PostgreSQLDatabaseList
     plural: postgresqldatabases
+    shortNames:
+    - pgdb
     singular: postgresqldatabase
   scope: Namespaced
   subresources:

--- a/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
+++ b/deploy/crds/lunarway.com_postgresqlusers_crd.yaml
@@ -8,6 +8,8 @@ spec:
     kind: PostgreSQLUser
     listKind: PostgreSQLUserList
     plural: postgresqlusers
+    shortNames:
+    - pguser
     singular: postgresqluser
   scope: Namespaced
   subresources:

--- a/pkg/apis/lunarway/v1alpha1/postgresqldatabase_types.go
+++ b/pkg/apis/lunarway/v1alpha1/postgresqldatabase_types.go
@@ -43,7 +43,7 @@ type PostgreSQLDatabaseStatus struct {
 // PostgreSQLDatabase is the Schema for the postgresqldatabases API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=postgresqldatabases,scope=Namespaced
+// +kubebuilder:resource:path=postgresqldatabases,scope=Namespaced,shortName=pgdb
 // +kubebuilder:printcolumn:name="Database",type="string",JSONPath=".spec.name",description="Database name"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Database status"
 // +kubebuilder:printcolumn:name="Updated",type="date",JSONPath=".status.phaseUpdated",description="Timestamp of last status update"

--- a/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
+++ b/pkg/apis/lunarway/v1alpha1/postgresqluser_types.go
@@ -48,7 +48,7 @@ type PostgreSQLUserStatus struct {
 // PostgreSQLUser is the Schema for the postgresqlusers API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=postgresqlusers,scope=Namespaced
+// +kubebuilder:resource:path=postgresqlusers,scope=Namespaced,shortName=pguser
 type PostgreSQLUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This change adds two short names for PostgreSQLDatabase and PostgreSQLUser to
make them a bit more easy to work with from kubectl.

    $ kubectl get pgdb
    NAME         DATABASE   STATUS    UPDATED
    product-db   product    Running   17m