### PR TITLE
Update README with info on how to get up and running locally with kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test/integration: test/integration/postgresql/run
 .PHONY: test/cluster
 test/cluster:
 	@echo Create test cluster
+	export KUBECONFIG=~/.kube/config
 	kind create cluster --name postgresql-controller-test
 
 .PHONY: test/cluster/resources

--- a/README.md
+++ b/README.md
@@ -180,17 +180,11 @@ Below example will create a test cluster, apply CRD resources, start a PostgreSQ
 Make sure to forward the postgresql pod for the
 
 ```
-// Setup kind cluster
+// Setup kind cluster (this will use KUBECONFIG=~/.kube/config to store the kubeconfig)
 $ make test/cluster
-
-// Point kubectl to the cluster (this command is also written to stdout by kind)
-$ export KUBECONFIG="$(kind get kubeconfig-path --name="postgresql-controller-test")"
 
 // Apply kubernetes resources for the controller
 $ make test/cluster/resources
-
-// Start a PostreSQL instance
-$ make test/cluster/postgresql
 
 // Forward PostgreSQL pod before starting the operator
 $ kubectl port-forward deploy/postgresql 5432


### PR DESCRIPTION
This PR changes the default kubeconfig to be used to `~/.kube/config` as `kind get kubeconfig-path` is deprecated.
```
`kind get kubeconfig-path` is deprecated!

KIND will export and merge kubeconfig like kops, minikube, etc.
This command is now unnecessary and will be removed in a future release.

For more info see: https://github.com/kubernetes-sigs/kind/issues/1060
See also the output of `kind create cluster`
```

This PR further updates the README on how to get up and running locally with kind. 