### PR TITLE
Disable reconcile sync loop

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -103,6 +103,7 @@ func main() {
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		SyncPeriod:         nil,
 	})
 	if err != nil {
 		log.Error(err, "")


### PR DESCRIPTION
The default `SyncPeriod` is 10 hours, which is concurrent with what we see in our monitoring. 

As we only want to have the controller react to events; Created/updated and deleted for now, let's just disable it.