### PR TITLE
Fix database connection usage

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	pflag.CommandLine.AddFlagSet(postgresqldatabase.FlagSet)
 	pflag.CommandLine.AddFlagSet(postgresqluser.FlagSet)
-
+	resyncDuration := pflag.CommandLine.Duration("resync-period", 10*time.Hour, "determines the minimum frequency at which watched resources are reconciled")
 	pflag.Parse()
 
 	// Use a zap logr.Logger implementation. If none of the zap
@@ -103,7 +103,7 @@ func main() {
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-		SyncPeriod:         nil,
+		SyncPeriod:         resyncDuration,
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -87,6 +87,12 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials)
 	if err != nil {
 		return fmt.Errorf("connect with new user %s: %w", credentials.Name, err)
 	}
+	defer func() {
+		err := serviceConnection.Close()
+		if err != nil {
+			log.Error(err, "failed to close service database connection", "host", host, "database", credentials.Name, "user", credentials.Name)
+		}
+	}()
 
 	// Create schema in the database
 	err = createSchema(log, serviceConnection, credentials.Name)

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -47,6 +47,8 @@ func Connect(log logr.Logger, connectionString ConnectionString) (*sql.DB, error
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxIdleConns(0)
+	db.SetMaxOpenConns(1)
 	err = db.Ping()
 	if err != nil {
 		return nil, err

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -48,7 +48,6 @@ func Connect(log logr.Logger, connectionString ConnectionString) (*sql.DB, error
 		return nil, err
 	}
 	db.SetMaxIdleConns(0)
-	db.SetMaxOpenConns(1)
 	err = db.Ping()
 	if err != nil {
 		return nil, err

--- a/test/log.go
+++ b/test/log.go
@@ -29,3 +29,45 @@ func (l *logger) Write(p []byte) (int, error) {
 	l.t.Logf("%s", p)
 	return len(p), nil
 }
+
+// RawLogger implements a test logger that will log any info or log lines to a
+// testing.T.Logf function.
+type RawLogger struct {
+	T      *testing.T
+	name   string
+	values []interface{}
+}
+
+var _ logr.Logger = &RawLogger{}
+
+func (t *RawLogger) Info(msg string, keysAndValues ...interface{}) {
+	t.T.Logf("INFO:  %s KEYPAIRS: %v", msg, keysAndValues)
+}
+
+func (t *RawLogger) Enabled() bool {
+	return true
+}
+
+func (t *RawLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	t.T.Logf("ERROR: %s: %v KEYPAIRS: %v", msg, err, keysAndValues)
+}
+
+func (t *RawLogger) V(level int) logr.InfoLogger {
+	return t
+}
+
+func (t *RawLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	return &RawLogger{
+		T:      t.T,
+		name:   t.name,
+		values: append(t.values, keysAndValues...),
+	}
+}
+
+func (t *RawLogger) WithName(name string) logr.Logger {
+	return &RawLogger{
+		T:      t.T,
+		name:   name,
+		values: t.values,
+	}
+}


### PR DESCRIPTION
This PR mitigates the surges in database connections we have seen when having a
large number of resources reconciled.

The controller-runtime `manager.Manager` has an internal resync loop controlled
with [`SyncPeriod`](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L110-L116) that will list all watched resources and reconcile them
synchronously. When ever we reconcile a resource we establish a connection to
the database that is very short lived, as we do not know if we will reconcile a
resource against the same database later on. As the default settings in `sql.DB`
allows 2 idle connection by default they can potentially stick around longer
than necessary.

This is fixed by explicitly setting `MaxIddleConns` to 0 and `MaxOpenConns` to
1. I've added a test that confirms that this reduces the number of simultaneous
connections appropriately.

Further more the PR adds a `resync-period` flag that controls the before
mentioned resync loop as to let us test this behaviour without having to rebuild
the controller.

During my investigation I also found a connection leak. This is confirmed by
looking at running Go routines in a dashboard in our dev environment. It is now
closed as it should.
![image](https://user-images.githubusercontent.com/6881694/75456251-92ae4c80-597a-11ea-9270-1b859ee66258.png)