### PR TITLE
Log when allDatabases results on no grants

### DIFF
--- a/pkg/grants/grants_test.go
+++ b/pkg/grants/grants_test.go
@@ -173,6 +173,15 @@ func TestReconcilePostgreSQLUser_groupAccesses_withAllDatabases(t *testing.T) {
 		output    grants.HostAccess
 	}{
 		{
+			name:      "no databases on host",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: nil,
+			output: nil,
+		},
+		{
 			name: "single allDatabases read",
 			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
 				database("host1:5432", "database"),


### PR DESCRIPTION
If flag allDatabases is set on an access request we silently proceed without
granting anything.

This is expected, but can be hard to understand from the logs.

This change adds a log line when this happens so one can see that we correctly
handled the request but found nothing to add.