### PR TITLE
Change lunarway.com to lunar.app domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ A policy will also be added to AWS IAM for the specific user allowing it to conn
       ],
       "Condition": {
         "StringLike": {
-          "aws:userid": "*:<name>@lunarway.com"
+          "aws:userid": "*:<name>@lunar.app"
         }
       }
     }

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -107,7 +107,7 @@ func SetAWSPolicy(log logr.Logger, credentials *credentials.Credentials, policy 
 }
 
 func (p *PolicyDocument) appendStatement(userID, awsAccountID, region string) {
-	awsUserID := fmt.Sprintf("*:%s@lunarway.com", userID)
+	awsUserID := fmt.Sprintf("*:%s@lunar.app", userID)
 	s := StatementEntry{
 		Effect:    "Allow",
 		Action:    []string{"rds-db:connect"},

--- a/pkg/iam/iam_test.go
+++ b/pkg/iam/iam_test.go
@@ -2,8 +2,9 @@ package iam
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPolicyDocument_appendStatement(t *testing.T) {
@@ -53,5 +54,5 @@ func entry(userID string) StatementEntry {
 		Effect:    "Allow",
 		Action:    []string{"rds-db:connect"},
 		Resource:  []string{fmt.Sprintf("arn:aws:rds-db:%s:%s:dbuser:*/iam_developer_%s", "region", "account", userID)},
-		Condition: StringLike{StringLike: UserID{AWSUserID: fmt.Sprintf("*:%s@lunarway.com", userID)}}}
+		Condition: StringLike{StringLike: UserID{AWSUserID: fmt.Sprintf("*:%s@lunar.app", userID)}}}
 }


### PR DESCRIPTION
The AWS IAM policies should reference lunar.app instead of lunarway.com after
we've switched to the former.