### PR TITLE
Grant access based on schema name

### DIFF
--- a/pkg/grants/grants_test.go
+++ b/pkg/grants/grants_test.go
@@ -142,6 +142,9 @@ func TestReconcilePostgreSQLUser_groupAccesses_withAllDatabases(t *testing.T) {
 				Host: lunarwayv1alpha1.ResourceVar{
 					Value: host,
 				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: "user",
+				},
 			},
 		}
 	}
@@ -159,7 +162,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_withAllDatabases(t *testing.T) {
 			Host: host,
 			Database: postgres.DatabaseSchema{
 				Name:       database,
-				Schema:     database,
+				Schema:     "user",
 				Privileges: privilige,
 			},
 			Access: spec(host, reason),
@@ -316,6 +319,9 @@ func TestReconcilePostgreSQLUser_groupAccesses_allDatabasesFeatureFlags(t *testi
 				Host: lunarwayv1alpha1.ResourceVar{
 					Value: host,
 				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: "user",
+				},
 			},
 		}
 	}
@@ -333,7 +339,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_allDatabasesFeatureFlags(t *testi
 			Host: host,
 			Database: postgres.DatabaseSchema{
 				Name:       database,
-				Schema:     database,
+				Schema:     "user",
 				Privileges: privilige,
 			},
 			Access: spec(host, reason),
@@ -422,6 +428,9 @@ func TestReconcilePostgreSQLUser_groupAccesses_mixedSpecs(t *testing.T) {
 				Host: lunarwayv1alpha1.ResourceVar{
 					Value: host,
 				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: "user",
+				},
 			},
 		}
 	}
@@ -443,7 +452,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_mixedSpecs(t *testing.T) {
 				Value: database,
 			},
 			Schema: lunarwayv1alpha1.ResourceVar{
-				Value: database,
+				Value: "user",
 			},
 			Reason: reason,
 		}
@@ -453,7 +462,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_mixedSpecs(t *testing.T) {
 			Host: host,
 			Database: postgres.DatabaseSchema{
 				Name:       database,
-				Schema:     database,
+				Schema:     "user",
 				Privileges: privilige,
 			},
 			Access: allDatabasesSpec(host, reason),
@@ -464,7 +473,7 @@ func TestReconcilePostgreSQLUser_groupAccesses_mixedSpecs(t *testing.T) {
 			Host: host,
 			Database: postgres.DatabaseSchema{
 				Name:       database,
-				Schema:     database,
+				Schema:     "user",
 				Privileges: privilige,
 			},
 			Access: singleDatabaseSpec(host, database, reason),

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -281,6 +281,8 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 
 	epoch := time.Now().UnixNano()
 	sharedDatabaseName := fmt.Sprintf("shared_%d", epoch)
+	newUser := fmt.Sprintf("new_user_%d", epoch)
+	developer := fmt.Sprintf("developer_%d", epoch)
 
 	// create the shared database with a role of the same name and owned by the
 	// shared role
@@ -303,8 +305,6 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 		t.Fatalf("connect to sahred database failed: %v", err)
 	}
 	defer sharedConn.Close()
-
-	newUser := "new_user"
 
 	// create schema and table that is to be used by a new role but owned by the
 	// existing shared user
@@ -361,9 +361,9 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	assert.Equal(t, []string{"value-from-new-user", "value-from-shared-user"}, nonOwned, "nonowned rows not as expected")
 
 	// request access to the new user schema of the shared database
-	err = postgres.Role(log, db, "developer", nil, []postgres.DatabaseSchema{
+	err = postgres.Role(log, db, developer, nil, []postgres.DatabaseSchema{
 		postgres.DatabaseSchema{
-			Name:       newUser,
+			Name:       sharedDatabaseName,
 			Privileges: postgres.PrivilegeRead,
 			Schema:     newUser,
 		},
@@ -376,7 +376,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	developerConn, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: sharedDatabaseName,
-		User:     "developer",
+		User:     developer,
 		Password: "",
 	})
 	if err != nil {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -113,10 +113,15 @@ func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []
 		if len(schemaPrivileges) == 0 {
 			continue
 		}
+		schema := database.Schema
+		if strings.EqualFold(schema, "public") {
+			schema = database.Name
+		}
+		schemaPrivileges = fmt.Sprintf("%s_%s", schema, schemaPrivileges)
 		log.Info(fmt.Sprintf("Granting %s to %s", schemaPrivileges, name))
-		_, err = db.Exec(fmt.Sprintf("GRANT %s_%s TO %s", database.Name, schemaPrivileges, name))
+		_, err = db.Exec(fmt.Sprintf("GRANT %s TO %s", schemaPrivileges, name))
 		if err != nil {
-			return fmt.Errorf("grant access privileges '%s' on schema '%s': %w", schemaPrivileges, database.Schema, err)
+			return fmt.Errorf("grant access privileges '%s' on schema '%s': %w", schemaPrivileges, schema, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
When using shared databases the database name is the same between multiple
schemas, but when granting access from a `PostgreSQLUser` we request access on a
specific schema of a shared database. This results in read and readwrite access
grants are based on the database name roles instead of the schema specific ones.
This results in the grants not actually granting access to the schemas.

This change set changes the grants to based on the schema name instead and thus
the read and readwrite roles are properly granted.

It also fixes the limitation of `allDatabases` that would not work with shared
databases by using the User as the schema name.

Lastly I've change the logs a bit to be more meaningful and provide some context.