### PR TITLE
Log reconciliation errors with request id

### DIFF
--- a/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
+++ b/pkg/controller/postgresqldatabase/postgresqldatabase_controller.go
@@ -129,6 +129,10 @@ func (r *ReconcilePostgreSQLDatabase) Reconcile(request reconcile.Request) (reco
 	reqLogger = reqLogger.WithValues("requestId", requestID.String())
 	status, err := r.reconcile(reqLogger, request)
 	status.Persist(err)
+
+	if err != nil {
+		reqLogger.Error(err, "Failed to reconcile PostgreSQLDatabase object")
+	}
 	return reconcile.Result{}, stopRequeueOnInvalid(reqLogger, err)
 }
 

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -183,7 +183,7 @@ type ReconcilePostgreSQLUser struct {
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-func (r *ReconcilePostgreSQLUser) Reconcile(request reconcile.Request) (_ reconcile.Result, err error) {
+func (r *ReconcilePostgreSQLUser) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	requestID, err := uuid.NewRandom()
 	if err != nil {

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -183,7 +183,7 @@ type ReconcilePostgreSQLUser struct {
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-func (r *ReconcilePostgreSQLUser) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcilePostgreSQLUser) Reconcile(request reconcile.Request) (_ reconcile.Result, err error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	requestID, err := uuid.NewRandom()
 	if err != nil {
@@ -192,9 +192,17 @@ func (r *ReconcilePostgreSQLUser) Reconcile(request reconcile.Request) (reconcil
 	reqLogger = reqLogger.WithValues("requestId", requestID.String())
 	reqLogger.Info("Reconciling PostgreSQLUSer")
 
+	result, err := r.reconcile(reqLogger, request)
+	if err != nil {
+		reqLogger.Error(err, "Failed to reconcile PostgreSQLUser object")
+	}
+	return result, err
+}
+
+func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the PostgreSQLUser instance
 	user := &lunarwayv1alpha1.PostgreSQLUser{}
-	err = r.client.Get(context.TODO(), request.NamespacedName, user)
+	err := r.client.Get(context.TODO(), request.NamespacedName, user)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.


### PR DESCRIPTION
If a reconciliation fails the controller-runtime controller will log the error,
but doing so without the request id.

This change set adds another error log to the controllers on exit logging the
same error but with the contextual logger as to get the request id logged along
with the error.

![image](https://user-images.githubusercontent.com/6881694/78238438-df86c500-74dc-11ea-976d-9458e9afd688.png)
