### PR TITLE
Support missing user for AllDatabases grants

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	errNoValue    = ctrerrors.NewInvalid(errors.New("no value"))
+	// ErrNoValue indicates that a resource could not be resolved to a value.
+	ErrNoValue    = ctrerrors.NewInvalid(errors.New("no value"))
 	errNotFound   = ctrerrors.NewTemporary(ctrerrors.NewInvalid(errors.New("not found")))
 	errUnknownKey = ctrerrors.NewTemporary(ctrerrors.NewInvalid(errors.New("unknown key")))
 )
@@ -51,7 +52,7 @@ func ResourceValue(client client.Client, resource lunarwayv1alpha1.ResourceVar, 
 		return v, nil
 	}
 
-	return "", errNoValue
+	return "", ErrNoValue
 }
 
 func SecretValue(client client.Client, namespacedName types.NamespacedName, key string) (string, error) {


### PR DESCRIPTION
If a `PostgreSQLUser` requests access to all databases with the `AllDatabases` flag
and one of the found `PostgreSQLDatabase` resources has not set the `User` field a
"no value" error is returned and granting fails.

This change set adds a fallback in case of the missing `User` field to the
database name as we do in package `postgres` when setting up database.