### PR TITLE
Add support for failures for allDatabases requests

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -221,7 +221,10 @@ func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request recon
 
 	accesses, err := r.granter.GroupAccesses(reqLogger, request.Namespace, user.Spec.Read, user.Spec.Write)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("group accesses: %w", err)
+		if len(accesses) == 0 {
+			return reconcile.Result{}, fmt.Errorf("group accesses: %w", err)
+		}
+		reqLogger.Error(err, fmt.Sprintf("Some access requests could not be resolved. Continuating with the resolved ones"))
 	}
 	reqLogger.Info(fmt.Sprintf("Found access requests for %d hosts", len(accesses)))
 

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func TestReconcile_connectToHosts(t *testing.T) {
@@ -178,7 +178,7 @@ func TestParseHostCredentials(t *testing.T) {
 // reconciliation of the remaining ones.
 func TestReconcile_badConfigmapReference(t *testing.T) {
 	// Set the logger to development mode for verbose logs.
-	log.SetLogger(log.ZapLogger(true))
+	logf.SetLogger(logf.ZapLogger(true))
 
 	host := test.Integration(t)
 	var (
@@ -292,7 +292,7 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 	}
 
 	// seed database1 into the postgres host
-	dbConn, err := postgres.Connect(log, postgres.ConnectionString{
+	dbConn, err := postgres.Connect(logf.Log, postgres.ConnectionString{
 		Database: "postgres",
 		Host:     host,
 		Password: "",
@@ -301,7 +301,7 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 	if !assert.NoError(t, err, "failed to connect to database to seed database") {
 		return
 	}
-	err = postgres.Database(log, dbConn, host, postgres.Credentials{
+	err = postgres.Database(logf.Log, dbConn, host, postgres.Credentials{
 		Name:     database1Name,
 		Password: "123456",
 		User:     database1Name,

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -5,10 +5,22 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/pkg/apis/lunarway/v1alpha1"
 	"go.lunarway.com/postgresql-controller/pkg/grants"
+	"go.lunarway.com/postgresql-controller/pkg/iam"
+	"go.lunarway.com/postgresql-controller/pkg/kube"
 	"go.lunarway.com/postgresql-controller/pkg/postgres"
 	"go.lunarway.com/postgresql-controller/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func TestReconcile_connectToHosts(t *testing.T) {
@@ -23,7 +35,7 @@ func TestReconcile_connectToHosts(t *testing.T) {
 		{
 			name: "single host with credentials",
 			credentials: map[string]postgres.Credentials{
-				"localhost:5432": postgres.Credentials{
+				"localhost:5432": {
 					Name:     "iam_creator",
 					Password: "",
 				},
@@ -37,11 +49,11 @@ func TestReconcile_connectToHosts(t *testing.T) {
 		{
 			name: "multiple hosts without upstream",
 			credentials: map[string]postgres.Credentials{
-				"localhost:5432": postgres.Credentials{
+				"localhost:5432": {
 					Name:     "iam_creator",
 					Password: "",
 				},
-				"unknown": postgres.Credentials{
+				"unknown": {
 					Name:     "iam_creator",
 					Password: "12345678",
 				},
@@ -113,7 +125,7 @@ func TestParseHostCredentials(t *testing.T) {
 				"host:5432": "user:password",
 			},
 			output: map[string]postgres.Credentials{
-				"host:5432": postgres.Credentials{
+				"host:5432": {
 					Name:     "user",
 					Password: "password",
 				},
@@ -127,11 +139,11 @@ func TestParseHostCredentials(t *testing.T) {
 				"host2:5432": "user2:password2",
 			},
 			output: map[string]postgres.Credentials{
-				"host1:5432": postgres.Credentials{
+				"host1:5432": {
 					Name:     "user1",
 					Password: "password1",
 				},
-				"host2:5432": postgres.Credentials{
+				"host2:5432": {
 					Name:     "user2",
 					Password: "password2",
 				},
@@ -158,4 +170,158 @@ func TestParseHostCredentials(t *testing.T) {
 			assert.Equal(t, tc.output, output, "output not as expected")
 		})
 	}
+}
+
+// TestReconcile_badConfigmapReference tests that reconcilation is completed
+// successfully even though a an error occours during database resolvement. This
+// is to ensure that a single bad PostgreSQLDatabase resource will not block the
+// reconciliation of the remaining ones.
+func TestReconcile_badConfigmapReference(t *testing.T) {
+	// Set the logger to development mode for verbose logs.
+	log.SetLogger(log.ZapLogger(true))
+
+	host := test.Integration(t)
+	var (
+		namespace     = "default"
+		database1Name = "database1"
+		database2Name = "database2"
+		userName      = "service_user"
+
+		// user requesting access to all databases on host
+		userResource = &lunarwayv1alpha1.PostgreSQLUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userName,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLUserSpec{
+				Name: userName,
+				Read: []lunarwayv1alpha1.AccessSpec{
+					{
+						Host: lunarwayv1alpha1.ResourceVar{
+							Value: host,
+						},
+						AllDatabases: true,
+					},
+				},
+			},
+		}
+
+		// valid database on host
+		database1Resource = &lunarwayv1alpha1.PostgreSQLDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      database1Name,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Name: database1Name,
+				Host: lunarwayv1alpha1.ResourceVar{
+					Value: host,
+				},
+				Password: lunarwayv1alpha1.ResourceVar{
+					Value: "123456",
+				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: database1Name,
+				},
+			},
+		}
+
+		// invalid database referencing a non-existing configmap
+		database2Resource = &lunarwayv1alpha1.PostgreSQLDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      database2Name,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Name: database2Name,
+				Host: lunarwayv1alpha1.ResourceVar{
+					ValueFrom: &lunarwayv1alpha1.ResourceVarSource{
+						ConfigMapKeyRef: &lunarwayv1alpha1.KeySelector{
+							Name: "unknown",
+						},
+					},
+				},
+				Password: lunarwayv1alpha1.ResourceVar{
+					Value: "12346",
+				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: database2Name,
+				},
+			},
+		}
+	)
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(lunarwayv1alpha1.SchemeGroupVersion, database1Resource)
+	s.AddKnownTypes(lunarwayv1alpha1.SchemeGroupVersion, userResource)
+	s.AddKnownTypes(lunarwayv1alpha1.SchemeGroupVersion, &lunarwayv1alpha1.PostgreSQLDatabaseList{})
+
+	// Add tracked objects to the fake client simulating their existence in a k8s
+	// cluster
+	objs := []runtime.Object{
+		database1Resource,
+		database2Resource,
+		userResource,
+	}
+	cl := fake.NewFakeClient(objs...)
+
+	// Create a controller object with the fake client but otherwise "live" setup
+	// with database interaction
+	r := &ReconcilePostgreSQLUser{
+		client: cl,
+		hostCredentials: map[string]postgres.Credentials{
+			host: {
+				Name:     "iam_creator",
+				Password: "",
+			},
+		},
+		granter: grants.Granter{
+			AllDatabasesReadEnabled:  true,
+			AllDatabasesWriteEnabled: true,
+			AllDatabases: func(namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
+				return kube.PostgreSQLDatabases(cl, namespace)
+			},
+			ResourceResolver: func(resource lunarwayv1alpha1.ResourceVar, namespace string) (string, error) {
+				return kube.ResourceValue(cl, resource, namespace)
+			},
+		},
+		setAWSPolicy: func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID string) error {
+			return nil
+		},
+	}
+
+	// seed database1 into the postgres host
+	dbConn, err := postgres.Connect(log, postgres.ConnectionString{
+		Database: "postgres",
+		Host:     host,
+		Password: "",
+		User:     "iam_creator",
+	})
+	if !assert.NoError(t, err, "failed to connect to database to seed database") {
+		return
+	}
+	err = postgres.Database(log, dbConn, host, postgres.Credentials{
+		Name:     database1Name,
+		Password: "123456",
+		User:     database1Name,
+	})
+	if !assert.NoError(t, err, "failed to seed database") {
+		return
+	}
+
+	// reconcile user requesting access to all databases with a bad database
+	// reference
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      userName,
+			Namespace: namespace,
+		},
+	}
+	res, err := r.Reconcile(req)
+	assert.NoError(t, err, "reconciliation failed")
+	assert.Equal(t, reconcile.Result{
+		Requeue:      false,
+		RequeueAfter: 0,
+	}, res, "result not as expected")
 }


### PR DESCRIPTION
If a database resources is not configured correctly, ie. unknown config map
reference or is temporarily in a bad state the controller is not able to grant
access to any databases when a user requests it with the `allDatabases` field.

This fails to support practical usage where some database objects will be in a
bad state at any time and thus puts the controller out of operation.

This change will only log an error if a database object cannot be resolved but
will continue reconciling any databases that are valid.

A controller test is added with a fake kubernetes client that contains two
databases, one good and one referencing an unknown config map. When reconciling
a `PostgreSQLUser` with `allDatabases` set we expect the reconciliation to complete
for the valid database.