### PR TITLE
Use request logger for grants.Granter

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -215,7 +215,7 @@ func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request recon
 	reqLogger = reqLogger.WithValues("user", user.Spec.Name)
 	reqLogger.Info("Reconciling found PostgreSQLUser resource", "user", user.Spec.Name)
 
-	err = r.granter.SyncUser(request.Namespace, *user)
+	err = r.granter.SyncUser(reqLogger, request.Namespace, *user)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("sync user grants: %w", err)
 	}

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -95,7 +95,7 @@ func TestParseHostCredentials(t *testing.T) {
 func TestReconcile_badConfigmapReference(t *testing.T) {
 	// Set the logger to development mode for verbose logs.
 	logf.SetLogger(logf.ZapLogger(true))
-	logger := logf.Log
+
 	host := test.Integration(t)
 	var (
 		namespace     = "default"

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -194,7 +194,6 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 					Password: "",
 				},
 			},
-			Log:                      logger,
 			AllDatabasesReadEnabled:  true,
 			AllDatabasesWriteEnabled: true,
 			AllDatabases: func(namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {

--- a/pkg/grants/grants_test.go
+++ b/pkg/grants/grants_test.go
@@ -121,7 +121,6 @@ func TestGranter_groupAccesses(t *testing.T) {
 			logger := test.NewLogger(t)
 			r := Granter{
 				Now: time.Now,
-				Log: logger,
 				ResourceResolver: func(r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 					return r.Value, nil
 				},
@@ -131,7 +130,7 @@ func TestGranter_groupAccesses(t *testing.T) {
 				},
 			}
 
-			output, err := r.groupAccesses("namespace", tc.reads, tc.writes)
+			output, err := r.groupAccesses(logger, "namespace", tc.reads, tc.writes)
 
 			assert.NoError(t, err, "unexpected output error")
 			assert.Equal(t, tc.output, output, "output map not as expected")
@@ -223,7 +222,6 @@ func TestGranter_groupAccesses_startStopHandling(t *testing.T) {
 				Now: func() time.Time {
 					return now
 				},
-				Log: logger,
 				ResourceResolver: func(r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 					return r.Value, nil
 				},
@@ -233,7 +231,7 @@ func TestGranter_groupAccesses_startStopHandling(t *testing.T) {
 				},
 			}
 
-			output, err := r.groupAccesses("namespace", []lunarwayv1alpha1.AccessSpec{tc.access}, nil)
+			output, err := r.groupAccesses(logger, "namespace", []lunarwayv1alpha1.AccessSpec{tc.access}, nil)
 
 			assert.NoError(t, err, "unexpected output error")
 			var hostAccess HostAccess
@@ -409,7 +407,6 @@ func TestGranter_groupAccesses_withAllDatabases(t *testing.T) {
 			logger := test.NewLogger(t)
 			r := Granter{
 				Now: time.Now,
-				Log: logger,
 				ResourceResolver: func(r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 					return r.Value, nil
 				},
@@ -420,7 +417,7 @@ func TestGranter_groupAccesses_withAllDatabases(t *testing.T) {
 				},
 			}
 
-			output, err := r.groupAccesses("namespace", tc.reads, tc.writes)
+			output, err := r.groupAccesses(logger, "namespace", tc.reads, tc.writes)
 
 			assert.NoError(t, err, "unexpected output error")
 			assert.Equal(t, tc.output, output, "output map not as expected")
@@ -520,7 +517,6 @@ func TestGranter_groupAccesses_allDatabasesFeatureFlags(t *testing.T) {
 			logger := test.NewLogger(t)
 			r := Granter{
 				Now: time.Now,
-				Log: logger,
 				ResourceResolver: func(r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 					return r.Value, nil
 				},
@@ -531,7 +527,7 @@ func TestGranter_groupAccesses_allDatabasesFeatureFlags(t *testing.T) {
 				},
 			}
 
-			output, err := r.groupAccesses("namespace", tc.reads, tc.writes)
+			output, err := r.groupAccesses(logger, "namespace", tc.reads, tc.writes)
 
 			assert.NoError(t, err, "unexpected output error")
 			assert.Equal(t, tc.output, output, "output map not as expected")
@@ -633,7 +629,6 @@ func TestGranter_groupAccesses_mixedSpecs(t *testing.T) {
 			logger := test.NewLogger(t)
 			r := Granter{
 				Now: time.Now,
-				Log: logger,
 				ResourceResolver: func(r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 					return r.Value, nil
 				},
@@ -644,7 +639,7 @@ func TestGranter_groupAccesses_mixedSpecs(t *testing.T) {
 				},
 			}
 
-			output, err := r.groupAccesses("namespace", tc.reads, tc.writes)
+			output, err := r.groupAccesses(logger, "namespace", tc.reads, tc.writes)
 
 			assert.NoError(t, err, "unexpected output error")
 			assert.Equal(t, tc.output, output, "output map not as expected")
@@ -688,12 +683,11 @@ func TestGranter_groupAccesses_errors(t *testing.T) {
 	logger := test.NewLogger(t)
 	r := Granter{
 		Now: time.Now,
-		Log: logger,
 		ResourceResolver: func(r lunarwayv1alpha1.ResourceVar, ns string) (string, error) {
 			return r.Value, fmt.Errorf("no value")
 		},
 	}
-	output, err := r.groupAccesses("namespace", reads, nil)
+	output, err := r.groupAccesses(logger, "namespace", reads, nil)
 
 	assert.EqualError(t, err, expectedError, "output error not as exepcted")
 	assert.Equal(t, HostAccess(nil), output, "output map not as expected")
@@ -757,12 +751,11 @@ func TestGranter_connectToHosts(t *testing.T) {
 
 			r := Granter{
 				Now:             time.Now,
-				Log:             logger,
 				HostCredentials: tc.credentials,
 			}
 
 			// act
-			connections, err := r.connectToHosts(tc.hostAccess)
+			connections, err := r.connectToHosts(logger, tc.hostAccess)
 
 			defer func() {
 				for _, db := range connections {
@@ -834,7 +827,6 @@ func TestGranter_groupAccesses_partialErrors(t *testing.T) {
 			logger := test.NewLogger(t)
 			r := Granter{
 				Now:                     time.Now,
-				Log:                     logger,
 				AllDatabasesReadEnabled: true,
 				AllDatabases: func(namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
 					return []lunarwayv1alpha1.PostgreSQLDatabase{
@@ -865,7 +857,7 @@ func TestGranter_groupAccesses_partialErrors(t *testing.T) {
 					return r.Value, nil
 				},
 			}
-			output, err := r.groupAccesses("namespace", tc.reads, nil)
+			output, err := r.groupAccesses(logger, "namespace", tc.reads, nil)
 
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error(), "output error not as exepcted")
@@ -913,7 +905,6 @@ func TestGranter_groupAccesses_noUserSchemaFallback_allDatabases(t *testing.T) {
 	logger := test.NewLogger(t)
 	r := Granter{
 		Now:                     time.Now,
-		Log:                     logger,
 		AllDatabasesReadEnabled: true,
 		AllDatabases: func(namespace string) ([]lunarwayv1alpha1.PostgreSQLDatabase, error) {
 			return []lunarwayv1alpha1.PostgreSQLDatabase{
@@ -940,7 +931,7 @@ func TestGranter_groupAccesses_noUserSchemaFallback_allDatabases(t *testing.T) {
 			return r.Value, nil
 		},
 	}
-	output, err := r.groupAccesses("namespace", reads, nil)
+	output, err := r.groupAccesses(logger, "namespace", reads, nil)
 
 	assert.NoError(t, err, "unexpected output error")
 	assert.Equal(t, expectedHostAccesses, output, "output map not as expected")


### PR DESCRIPTION
Currently we store a general logger in grants.Granter. Any log lines does that
way not have any context fields from a caller, e.g request ids.

This change set uses a logger in the first argument instead (like other methods
in the controller) and passes that along. This also fixes a panic when running
the controller as grants.Granter.Log was not set during startup.