### PR TITLE
Respect role prefix

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -212,7 +212,11 @@ func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request recon
 	}
 
 	// User instance created or updated
-	reqLogger = reqLogger.WithValues("user", user.Spec.Name)
+
+	// prefix name with configured rolePrefix
+	user.Spec.Name = fmt.Sprintf("%s%s", r.rolePrefix, user.Spec.Name)
+
+	reqLogger = reqLogger.WithValues("user", user.Spec.Name, "rolePrefix", r.rolePrefix)
 	reqLogger.Info("Reconciling found PostgreSQLUser resource", "user", user.Spec.Name)
 
 	err = r.granter.SyncUser(reqLogger, request.Namespace, *user)

--- a/pkg/grants/sync.go
+++ b/pkg/grants/sync.go
@@ -15,6 +15,7 @@ import (
 // defined in the host instances. Any excessive roles are removed and missing
 // ones are added.
 func (g *Granter) SyncUser(log logr.Logger, namespace string, user lunarwayv1alpha1.PostgreSQLUser) error {
+	log.Info(fmt.Sprintf("Syncing user %s", user.Spec.Name), "user", user)
 	//   resolve required grants taking expiration into account
 	//   diff against existing
 	//   revoke/grant what is needed
@@ -38,7 +39,7 @@ func (g *Granter) SyncUser(log logr.Logger, namespace string, user lunarwayv1alp
 		}
 	}()
 
-	err = g.setRolesOnHosts(log, user.Name, accesses, hosts)
+	err = g.setRolesOnHosts(log, user.Spec.Name, accesses, hosts)
 	if err != nil {
 		return fmt.Errorf("grant access on host: %w", err)
 	}


### PR DESCRIPTION
Roles are not created with the configured role-prefix. The bug was introduced in
46e333a80e8dd6ea7829ccd53c3d9578ef0c0575 (#54) where the user reconciliation
logic was moved out of package postgresqluser.

This change set prefixes the PostgreSQLUser specifications name with the
configured prefix in the controller.