### PR TITLE
Do not rewrite user.Spec.Name instead pass rolePrefix on

### DIFF
--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -211,7 +211,7 @@ func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request recon
 		return reconcile.Result{}, err
 	}
 
-	// prefix name with configured rolePrefix
+	// User instance created or updated
 	reqLogger = reqLogger.WithValues("user", user.Spec.Name, "rolePrefix", r.rolePrefix)
 	reqLogger.Info("Reconciling found PostgreSQLUser resource", "user", user.Spec.Name)
 

--- a/pkg/controller/postgresqluser/postgresqluser_controller.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller.go
@@ -160,7 +160,7 @@ type ReconcilePostgreSQLUser struct {
 	// that reads objects from the cache and writes to the apiserver
 	client       client.Client
 	granter      grants.Granter
-	setAWSPolicy func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID string) error
+	setAWSPolicy func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID, rolePrefix string) error
 
 	grantRoles         []string
 	rolePrefix         string
@@ -211,15 +211,11 @@ func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request recon
 		return reconcile.Result{}, err
 	}
 
-	// User instance created or updated
-
 	// prefix name with configured rolePrefix
-	user.Spec.Name = fmt.Sprintf("%s%s", r.rolePrefix, user.Spec.Name)
-
 	reqLogger = reqLogger.WithValues("user", user.Spec.Name, "rolePrefix", r.rolePrefix)
 	reqLogger.Info("Reconciling found PostgreSQLUser resource", "user", user.Spec.Name)
 
-	err = r.granter.SyncUser(reqLogger, request.Namespace, *user)
+	err = r.granter.SyncUser(reqLogger, request.Namespace, r.rolePrefix, *user)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("sync user grants: %w", err)
 	}
@@ -234,7 +230,7 @@ func (r *ReconcilePostgreSQLUser) reconcile(reqLogger logr.Logger, request recon
 		Name:      r.awsPolicyName,
 		Region:    r.awsRegion,
 		AccountID: r.awsAccountID,
-	}, user.Spec.Name)
+	}, user.Spec.Name, r.rolePrefix)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("set aws policy: %w", err)
 	}

--- a/pkg/controller/postgresqluser/postgresqluser_controller_test.go
+++ b/pkg/controller/postgresqluser/postgresqluser_controller_test.go
@@ -204,7 +204,7 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 				return kube.ResourceValue(cl, resource, namespace)
 			},
 		},
-		setAWSPolicy: func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID string) error {
+		setAWSPolicy: func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID, rolePrefix string) error {
 			return nil
 		},
 	}
@@ -335,7 +335,7 @@ func TestReconcile_rolePrefix(t *testing.T) {
 				return kube.ResourceValue(cl, resource, namespace)
 			},
 		},
-		setAWSPolicy: func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID string) error {
+		setAWSPolicy: func(log logr.Logger, credentials *credentials.Credentials, policy iam.AWSPolicy, userID, rolePrefix string) error {
 			return nil
 		},
 	}

--- a/pkg/grants/sync.go
+++ b/pkg/grants/sync.go
@@ -14,8 +14,9 @@ import (
 // SyncUser syncronizes a PostgreSQL user's access requests against the roles
 // defined in the host instances. Any excessive roles are removed and missing
 // ones are added.
-func (g *Granter) SyncUser(log logr.Logger, namespace string, user lunarwayv1alpha1.PostgreSQLUser) error {
-	log.Info(fmt.Sprintf("Syncing user %s", user.Spec.Name), "user", user)
+func (g *Granter) SyncUser(log logr.Logger, namespace, rolePrefix string, user lunarwayv1alpha1.PostgreSQLUser) error {
+	prefixedUsername := fmt.Sprintf("%s%s", rolePrefix, user.Spec.Name)
+	log.Info(fmt.Sprintf("Syncing user %s", prefixedUsername), "user", user)
 	//   resolve required grants taking expiration into account
 	//   diff against existing
 	//   revoke/grant what is needed
@@ -39,7 +40,7 @@ func (g *Granter) SyncUser(log logr.Logger, namespace string, user lunarwayv1alp
 		}
 	}()
 
-	err = g.setRolesOnHosts(log, user.Spec.Name, accesses, hosts)
+	err = g.setRolesOnHosts(log, prefixedUsername, accesses, hosts)
 	if err != nil {
 		return fmt.Errorf("grant access on host: %w", err)
 	}

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -111,7 +111,7 @@ func (p *PolicyDocument) appendStatement(initials, rolePrefix, awsAccountID, reg
 	s := StatementEntry{
 		Effect:    "Allow",
 		Action:    []string{"rds-db:connect"},
-		Resource:  []string{fmt.Sprintf("arn:aws:rds-db:%s:%s:dbuser:*/%s_%s", region, awsAccountID, rolePrefix, initials)},
+		Resource:  []string{fmt.Sprintf("arn:aws:rds-db:%s:%s:dbuser:*/%s%s", region, awsAccountID, rolePrefix, initials)},
 		Condition: StringLike{StringLike: UserID{AWSUserID: awsUserID}},
 	}
 

--- a/pkg/iam/iam_test.go
+++ b/pkg/iam/iam_test.go
@@ -10,6 +10,7 @@ import (
 func TestPolicyDocument_appendStatement(t *testing.T) {
 	type input struct {
 		userID       string
+		rolePrefix   string
 		awsAccountID string
 		region       string
 	}
@@ -22,19 +23,19 @@ func TestPolicyDocument_appendStatement(t *testing.T) {
 		{
 			name:      "empty policy",
 			statement: nil,
-			input:     input{userID: "test", awsAccountID: "account", region: "region"},
+			input:     input{userID: "test", rolePrefix: "iam_developer_", awsAccountID: "account", region: "region"},
 			output:    []StatementEntry{entry("test")},
 		},
 		{
 			name:      "policy already exists",
 			statement: []StatementEntry{entry("test")},
-			input:     input{userID: "test", awsAccountID: "account", region: "region"},
+			input:     input{userID: "test", rolePrefix: "iam_developer_", awsAccountID: "account", region: "region"},
 			output:    []StatementEntry{entry("test")},
 		},
 		{
 			name:      "multiple policies",
 			statement: []StatementEntry{entry("test1"), entry("test2")},
-			input:     input{userID: "test3", awsAccountID: "account", region: "region"},
+			input:     input{userID: "test3", rolePrefix: "iam_developer_", awsAccountID: "account", region: "region"},
 			output:    []StatementEntry{entry("test1"), entry("test2"), entry("test3")},
 		},
 	}
@@ -43,7 +44,7 @@ func TestPolicyDocument_appendStatement(t *testing.T) {
 			p := &PolicyDocument{
 				Statement: tt.statement,
 			}
-			p.appendStatement(tt.input.userID, tt.input.awsAccountID, tt.input.region)
+			p.appendStatement(tt.input.userID, tt.input.rolePrefix, tt.input.awsAccountID, tt.input.region)
 			assert.Equal(t, tt.output, p.Statement, "")
 		})
 	}


### PR DESCRIPTION
This PR changes the fix implemented yesterday, which broke the aws policy even more because of the rolePrefix was already applied in that part of the flow.