### PR TITLE
Map configuration from flags to Granter

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,8 +79,13 @@ func main() {
 		Scheme: mgr.GetScheme(),
 
 		Granter: grants.Granter{
-			Now:                   time.Now,
-			ExtendedWritesEnabled: config.ExtendedWriteEnabled,
+			AllDatabasesReadEnabled:  config.AllDatabasesReadEnabled,
+			AllDatabasesWriteEnabled: config.AllDatabasesWriteEnabled,
+			ExtendedWritesEnabled:    config.ExtendedWriteEnabled,
+			HostCredentials:          config.HostCredentials,
+			StaticRoles:              config.UserRoles,
+
+			Now: time.Now,
 			AllDatabases: func(namespace string) ([]postgresqlv1alpha1.PostgreSQLDatabase, error) {
 				return kube.PostgreSQLDatabases(mgr.GetClient(), namespace)
 			},


### PR DESCRIPTION
During the change on how flags are handled, the Granter was no longer configured
correctly according to the flags.

This change set adds mapping from the config fields to the Granter instantiation
in main.