### PR TITLE
Rename test of ParseUsernamePassword

### DIFF
--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -14,7 +14,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func TestParseHostCredentials(t *testing.T) {
+func TestParseUsernamePassword(t *testing.T) {
 	tt := []struct {
 		name   string
 		input  string
@@ -362,7 +362,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 
 	// request access to the new user schema of the shared database
 	err = postgres.Role(log, db, developer, nil, []postgres.DatabaseSchema{
-		postgres.DatabaseSchema{
+		{
 			Name:       sharedDatabaseName,
 			Privileges: postgres.PrivilegeRead,
 			Schema:     newUser,


### PR DESCRIPTION
The test name does not follow convention by mentioning the tested functions
name.

This change set fixes that along with a auto-formatting simplification of a
struct slice instantiation.