### PR TITLE
Regenerate open-api and CRD specification

### DIFF
--- a/api/v1alpha1/postgresqldatabase_types.go
+++ b/api/v1alpha1/postgresqldatabase_types.go
@@ -61,8 +61,15 @@ type PostgreSQLDatabaseSpec struct {
 type PostgreSQLDatabasePhase string
 
 const (
-	PostgreSQLDatabasePhaseFailed  PostgreSQLDatabasePhase = "Failed"
+	// PostgreSQLDatabasePhaseFailed indicates that the controller was unable to
+	// reconcile a database resource. It will be attempted again in the future.
+	PostgreSQLDatabasePhaseFailed PostgreSQLDatabasePhase = "Failed"
+	// PostgreSQLDatabasePhaseInvalid indicates that the controller was unable to
+	// reconcile the database as the specification of it is invalid and should be
+	// fixed. It will not be attempted again before the resource is updated.
 	PostgreSQLDatabasePhaseInvalid PostgreSQLDatabasePhase = "Invalid"
+	// PostgreSQLDatabasePhaseRunning indicates that the controller has reconciled
+	// the database and that it is available.
 	PostgreSQLDatabasePhaseRunning PostgreSQLDatabasePhase = "Running"
 )
 
@@ -110,7 +117,7 @@ func init() {
 	SchemeBuilder.Register(&PostgreSQLDatabase{}, &PostgreSQLDatabaseList{})
 }
 
-// PasswordVar represents an
+// ResourceVar represents a value or reference to a value.
 type ResourceVar struct {
 	// Defaults to "".
 	// +optional

--- a/api/v1alpha1/postgresqluser_types.go
+++ b/api/v1alpha1/postgresqluser_types.go
@@ -38,6 +38,7 @@ type PostgreSQLUserSpec struct {
 	Write []WriteAccessSpec `json:"write"`
 }
 
+// +k8s:openapi-gen=true
 type AccessSpec struct {
 	Host ResourceVar `json:"host"`
 	// +optional
@@ -53,8 +54,9 @@ type AccessSpec struct {
 	Stop metav1.Time `json:"stop"`
 }
 
+// +k8s:openapi-gen=true
 type WriteAccessSpec struct {
-	AccessSpec
+	AccessSpec `json:",inline"`
 	// +optional
 	Extended bool `json:"extended"`
 }

--- a/api/v1alpha1/postgresqluser_types.go
+++ b/api/v1alpha1/postgresqluser_types.go
@@ -38,6 +38,7 @@ type PostgreSQLUserSpec struct {
 	Write []WriteAccessSpec `json:"write"`
 }
 
+// AccessSpec defines a read access request specification.
 // +k8s:openapi-gen=true
 type AccessSpec struct {
 	Host ResourceVar `json:"host"`
@@ -54,6 +55,7 @@ type AccessSpec struct {
 	Stop metav1.Time `json:"stop"`
 }
 
+// WriteAccessSpec defines a write access request specification.
 // +k8s:openapi-gen=true
 type WriteAccessSpec struct {
 	AccessSpec `json:",inline"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -28,12 +28,66 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
+		"./api/v1alpha1.AccessSpec":               schema__api_v1alpha1_AccessSpec(ref),
 		"./api/v1alpha1.PostgreSQLDatabase":       schema__api_v1alpha1_PostgreSQLDatabase(ref),
 		"./api/v1alpha1.PostgreSQLDatabaseSpec":   schema__api_v1alpha1_PostgreSQLDatabaseSpec(ref),
 		"./api/v1alpha1.PostgreSQLDatabaseStatus": schema__api_v1alpha1_PostgreSQLDatabaseStatus(ref),
 		"./api/v1alpha1.PostgreSQLUser":           schema__api_v1alpha1_PostgreSQLUser(ref),
 		"./api/v1alpha1.PostgreSQLUserSpec":       schema__api_v1alpha1_PostgreSQLUserSpec(ref),
 		"./api/v1alpha1.PostgreSQLUserStatus":     schema__api_v1alpha1_PostgreSQLUserStatus(ref),
+		"./api/v1alpha1.WriteAccessSpec":          schema__api_v1alpha1_WriteAccessSpec(ref),
+	}
+}
+
+func schema__api_v1alpha1_AccessSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"host": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./api/v1alpha1.ResourceVar"),
+						},
+					},
+					"allDatabases": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"database": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./api/v1alpha1.ResourceVar"),
+						},
+					},
+					"schema": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./api/v1alpha1.ResourceVar"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"start": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+					"stop": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+				},
+				Required: []string{"host", "reason"},
+			},
+		},
+		Dependencies: []string{
+			"./api/v1alpha1.ResourceVar", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -283,5 +337,63 @@ func schema__api_v1alpha1_PostgreSQLUserStatus(ref common.ReferenceCallback) com
 				Type:        []string{"object"},
 			},
 		},
+	}
+}
+
+func schema__api_v1alpha1_WriteAccessSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"host": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./api/v1alpha1.ResourceVar"),
+						},
+					},
+					"allDatabases": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"database": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./api/v1alpha1.ResourceVar"),
+						},
+					},
+					"schema": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./api/v1alpha1.ResourceVar"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"start": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+					"stop": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+					"extended": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"host", "reason"},
+			},
+		},
+		Dependencies: []string{
+			"./api/v1alpha1.ResourceVar", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -43,7 +43,8 @@ func schema__api_v1alpha1_AccessSpec(ref common.ReferenceCallback) common.OpenAP
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "AccessSpec defines a read access request specification.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"host": {
 						SchemaProps: spec.SchemaProps{
@@ -344,7 +345,8 @@ func schema__api_v1alpha1_WriteAccessSpec(ref common.ReferenceCallback) common.O
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "WriteAccessSpec defines a write access request specification.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"host": {
 						SchemaProps: spec.SchemaProps{

--- a/config/crd/bases/postgresql.lunar.tech_postgresqlusers.yaml
+++ b/config/crd/bases/postgresql.lunar.tech_postgresqlusers.yaml
@@ -228,6 +228,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  extended:
+                    type: boolean
                   host:
                     description: PasswordVar represents an
                     properties:

--- a/config/crd/bases/postgresql.lunar.tech_postgresqlusers.yaml
+++ b/config/crd/bases/postgresql.lunar.tech_postgresqlusers.yaml
@@ -42,11 +42,13 @@ spec:
               type: string
             read:
               items:
+                description: AccessSpec defines a read access request specification.
                 properties:
                   allDatabases:
                     type: boolean
                   database:
-                    description: PasswordVar represents an
+                    description: ResourceVar represents a value or reference to a
+                      value.
                     properties:
                       value:
                         description: Defaults to "".
@@ -87,7 +89,8 @@ spec:
                         type: object
                     type: object
                   host:
-                    description: PasswordVar represents an
+                    description: ResourceVar represents a value or reference to a
+                      value.
                     properties:
                       value:
                         description: Defaults to "".
@@ -130,7 +133,8 @@ spec:
                   reason:
                     type: string
                   schema:
-                    description: PasswordVar represents an
+                    description: ResourceVar represents a value or reference to a
+                      value.
                     properties:
                       value:
                         description: Defaults to "".
@@ -184,11 +188,13 @@ spec:
               x-kubernetes-list-type: atomic
             write:
               items:
+                description: WriteAccessSpec defines a write access request specification.
                 properties:
                   allDatabases:
                     type: boolean
                   database:
-                    description: PasswordVar represents an
+                    description: ResourceVar represents a value or reference to a
+                      value.
                     properties:
                       value:
                         description: Defaults to "".
@@ -231,7 +237,8 @@ spec:
                   extended:
                     type: boolean
                   host:
-                    description: PasswordVar represents an
+                    description: ResourceVar represents a value or reference to a
+                      value.
                     properties:
                       value:
                         description: Defaults to "".
@@ -274,7 +281,8 @@ spec:
                   reason:
                     type: string
                   schema:
-                    description: PasswordVar represents an
+                    description: ResourceVar represents a value or reference to a
+                      value.
                     properties:
                       value:
                         description: Defaults to "".


### PR DESCRIPTION
Some how I missed this as well in an earlier change set.