### PR TITLE
Fix run make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ manager: fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	go run .
 
 # Install CRDs into a cluster
 install: manifests kustomize


### PR DESCRIPTION
Having multiple files in root breaks direct reference of main.go.

This change set makes the Go toolchain use the root as a package instead.