### PR TITLE
Ignore non-running databases when reconciling user

### DIFF
--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -218,6 +218,9 @@ func TestReconcile_rolePrefix(t *testing.T) {
 					Value: database1Name,
 				},
 			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+			},
 		}
 	)
 
@@ -342,6 +345,9 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 					Value: database1Name,
 				},
 			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+			},
 		}
 		database2Resource = &lunarwayv1alpha1.PostgreSQLDatabase{
 			ObjectMeta: metav1.ObjectMeta{
@@ -359,6 +365,9 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 				User: lunarwayv1alpha1.ResourceVar{
 					Value: database2Name,
 				},
+			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
 			},
 		}
 	)

--- a/pkg/grants/grants.go
+++ b/pkg/grants/grants.go
@@ -171,6 +171,10 @@ func (g *Granter) groupAllDatabasesByHost(reqLogger logr.Logger, hosts HostAcces
 	var errs error
 	for _, databaseResource := range databases {
 		database := databaseResource.Spec.Name
+		if databaseResource.Status.Phase != lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning {
+			reqLogger.Error(fmt.Errorf("database not in phase running"), fmt.Sprintf("Skipping resource '%s' as it is not in phase running", database))
+			continue
+		}
 		databaseHost, err := g.ResourceResolver(databaseResource.Spec.Host, namespace)
 		if err != nil {
 			errs = multierr.Append(errs, fmt.Errorf("resolve database '%s' host name: %w", databaseResource.Spec.Name, err))

--- a/pkg/grants/grants_test.go
+++ b/pkg/grants/grants_test.go
@@ -293,6 +293,9 @@ func TestGranter_groupAccesses_withAllDatabases(t *testing.T) {
 					Value: "user",
 				},
 			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+			},
 		}
 	}
 	spec := func(host, reason string) lunarwayv1alpha1.AccessSpec {
@@ -435,6 +438,30 @@ func TestGranter_groupAccesses_withAllDatabases(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "database in invalid phase",
+			databases: []lunarwayv1alpha1.PostgreSQLDatabase{
+				{
+					Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+						Name: "invalid",
+						Host: lunarwayv1alpha1.ResourceVar{
+							Value: "host1:5432",
+						},
+						User: lunarwayv1alpha1.ResourceVar{
+							Value: "user",
+						},
+					},
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseInvalid,
+					},
+				},
+			},
+			reads: []lunarwayv1alpha1.AccessSpec{
+				spec("host1:5432", "I am a developer"),
+			},
+			writes: nil,
+			output: nil,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -470,6 +497,9 @@ func TestGranter_groupAccesses_allDatabasesFeatureFlags(t *testing.T) {
 				User: lunarwayv1alpha1.ResourceVar{
 					Value: "user",
 				},
+			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
 			},
 		}
 	}
@@ -582,6 +612,9 @@ func TestGranter_groupAccesses_mixedSpecs(t *testing.T) {
 				User: lunarwayv1alpha1.ResourceVar{
 					Value: "user",
 				},
+			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
 			},
 		}
 	}
@@ -899,6 +932,9 @@ func TestGranter_groupAccesses_partialErrors(t *testing.T) {
 									Value: "host1",
 								},
 							},
+							Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+								Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+							},
 						},
 						{
 							Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
@@ -908,6 +944,9 @@ func TestGranter_groupAccesses_partialErrors(t *testing.T) {
 									// used in test to indicate that this should not be found
 									ValueFrom: &lunarwayv1alpha1.ResourceVarSource{},
 								},
+							},
+							Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+								Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
 							},
 						},
 					}, nil
@@ -981,6 +1020,9 @@ func TestGranter_groupAccesses_noUserSchemaFallback_allDatabases(t *testing.T) {
 						Host: lunarwayv1alpha1.ResourceVar{
 							Value: "host1:5432",
 						},
+					},
+					Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+						Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
 					},
 				},
 			}, nil


### PR DESCRIPTION
Currently, if a database is in an invalid of failed reconciliation phase,
`PostgreSQLUser` resources cannot be reconciled if they enable flag `allDatabases`.
This results in all `PostgreSQLUser` resources with this flag will never be
applied for all other databases available as well.

This change introduces a guard in the `allDatabases` grouping skipping any
non-running databases. If a database is under startup, ie. empty phase, they are
also ignored but will be considered on the next reconciliation.