### PR TITLE
Add flags for logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,10 +54,14 @@ func main() {
 	config := controllerConfiguration{}
 	config.RegisterFlags(flagSet)
 	flagSet.AddGoFlagSet(flag.CommandLine)
+	zapFlagSet := flag.NewFlagSet("zap-flags", flag.ExitOnError)
+	loggerOptions := zap.Options{}
+	loggerOptions.BindFlags(zapFlagSet)
+	flagSet.AddGoFlagSet(zapFlagSet)
+
 	flagSet.Parse(os.Args[1:])
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&loggerOptions)))
 	config.Log(setupLog)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION
Currently the controller logs in development mode and this cannot be configured
at runtime.

This chagen adds the zap loggers flagset to the controller flag set. This
changes the default logging setup to be production and allows us to control
other log configs, eg. level.