### PR TITLE
Add support for params on host credentials

### DIFF
--- a/config.go
+++ b/config.go
@@ -103,7 +103,7 @@ func (h *hostCredentials) Set(val string) error {
 			return fmt.Errorf("parse host '%s' failed: %w", hostCredential, err)
 		}
 		if len(parts) == 3 {
-			parsedCrendetials.Params = strings.TrimPrefix(parts[2], "params=")
+			parsedCrendetials.Params = parts[2]
 		}
 		(*h.value)[host] = parsedCrendetials
 	}

--- a/config.go
+++ b/config.go
@@ -90,8 +90,8 @@ func (h *hostCredentials) Set(val string) error {
 	}
 	hostCredentials := strings.Split(val, ",")
 	for _, hostCredential := range hostCredentials {
-		parts := strings.Split(hostCredential, "=")
-		if len(parts) != 2 {
+		parts := strings.SplitN(hostCredential, "=", 3)
+		if len(parts) != 2 && len(parts) != 3 {
 			return fmt.Errorf("%s must be formatted as key=value", hostCredential)
 		}
 		host, userPass := parts[0], parts[1]
@@ -101,6 +101,9 @@ func (h *hostCredentials) Set(val string) error {
 		parsedCrendetials, err := postgres.ParseUsernamePassword(userPass)
 		if err != nil {
 			return fmt.Errorf("parse host '%s' failed: %w", hostCredential, err)
+		}
+		if len(parts) == 3 {
+			parsedCrendetials.Params = strings.TrimPrefix(parts[2], "params=")
 		}
 		(*h.value)[host] = parsedCrendetials
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -65,6 +65,18 @@ func TestHostCredentials_Set(t *testing.T) {
 			err:    errors.New("parse host 'host1:5432=' failed: username empty"),
 			output: map[string]postgres.Credentials{},
 		},
+		{
+			name:  "host with ssl configured",
+			value: "host1:5432=user1:pass1=params=sslmode=enabled",
+			err:   nil,
+			output: map[string]postgres.Credentials{
+				"host1:5432": {
+					Name:     "user1",
+					Password: "pass1",
+					Params:   "sslmode=enabled",
+				},
+			},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -67,7 +67,7 @@ func TestHostCredentials_Set(t *testing.T) {
 		},
 		{
 			name:  "host with ssl configured",
-			value: "host1:5432=user1:pass1=params=sslmode=enabled",
+			value: "host1:5432=user1:pass1=sslmode=enabled",
 			err:   nil,
 			output: map[string]postgres.Credentials{
 				"host1:5432": {

--- a/controllers/postgresqldatabase_controller.go
+++ b/controllers/postgresqldatabase_controller.go
@@ -207,6 +207,7 @@ func (r *PostgreSQLDatabaseReconciler) EnsurePostgreSQLDatabase(log logr.Logger,
 		Database: "postgres", // default database
 		User:     credentials.Name,
 		Password: credentials.Password,
+		Params:   credentials.Params,
 	}
 	db, err := postgres.Connect(log, connectionString)
 	if err != nil {

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -17,6 +17,7 @@ type Credentials struct {
 	User     string
 	Password string
 	Shared   bool
+	Params   string
 }
 
 func (c Credentials) Validate() error {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -20,6 +20,7 @@ type ConnectionString struct {
 	Database string
 	User     string
 	Password string
+	Params   string
 }
 
 // Raw returns a PostgreSQL connection string.
@@ -28,7 +29,12 @@ func (c ConnectionString) Raw() string {
 	if c.Database != "" {
 		raw += fmt.Sprintf("/%s", c.Database)
 	}
-	raw += "?sslmode=disable"
+	if c.Params != "" {
+		raw += fmt.Sprintf("?%s", c.Params)
+	} else {
+		// backwards compatibility
+		raw += "?sslmode=disable"
+	}
 	return raw
 }
 

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -53,6 +53,17 @@ func TestConnectionString_Raw(t *testing.T) {
 			},
 			raw: "postgresql://user:1234@host:5432/database?sslmode=disable",
 		},
+		{
+			name: "complete with params",
+			connectionString: postgres.ConnectionString{
+				Host:     "host:5432",
+				Database: "database",
+				User:     "user",
+				Password: "1234",
+				Params:   "sslmode=strict",
+			},
+			raw: "postgresql://user:1234@host:5432/database?sslmode=strict",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Currently the controller defaults to `sslmode=disable` for all host connections.
Further more additional connection parameters cannot be added if one would like
to do so.

This change introduces the option for adding params=<connection-params> to host
credentials in the `--host-crendetials` flag to allow specifying custom parameters.

If no params are specified, it defaults to existing behaviour, that is setting
`sslmod=disable`.

This will make it possible to fix #23.