### PR TITLE
Use versioned set-envtest.sh in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 .PHONY: test/unit
 test/unit: fmt vet
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh hhttps://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/235d62a9d93f0183035787518f26142000972b14/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; \
 	fetch_envtest_tools $(ENVTEST_ASSETS_DIR); \
 	setup_envtest_env $(ENVTEST_ASSETS_DIR); \

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 .PHONY: test/unit
 test/unit: fmt vet
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh hhttps://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/235d62a9d93f0183035787518f26142000972b14/hack/setup-envtest.sh
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/235d62a9d93f0183035787518f26142000972b14/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; \
 	fetch_envtest_tools $(ENVTEST_ASSETS_DIR); \
 	setup_envtest_env $(ENVTEST_ASSETS_DIR); \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ spec:
       start: 2019-09-16T10:00:00Z
       stop: 2019-09-16T14:00:00Z
 ```
+test
 
 From the configuration the user will be created with a `<name>` user on the host and granted rights to access the required databases.
 The flag `--user-role-prefix` can be used to prefix all created roles.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ spec:
       start: 2019-09-16T10:00:00Z
       stop: 2019-09-16T14:00:00Z
 ```
-test
 
 From the configuration the user will be created with a `<name>` user on the host and granted rights to access the required databases.
 The flag `--user-role-prefix` can be used to prefix all created roles.


### PR DESCRIPTION
qCurrently we rely on the master branch of controller-runtime where the
set-envtest.sh script no longer exists.

This change defines the latest git sha where the script still existed locking
down the version and ensuring reproducible builds in the future.