### PR TITLE
Fix RBAC on configmaps and secrets

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
   - postgresql.lunar.tech
   resources:
   - postgresqldatabases

--- a/controllers/postgresqldatabase_controller.go
+++ b/controllers/postgresqldatabase_controller.go
@@ -48,6 +48,7 @@ type PostgreSQLDatabaseReconciler struct {
 
 //+kubebuilder:rbac:groups=postgresql.lunar.tech,resources=postgresqldatabases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=postgresql.lunar.tech,resources=postgresqldatabases/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list
 
 func (r *PostgreSQLDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)

--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -65,6 +65,7 @@ const userFinalizer = "postgresqluser.lunar.tech/finalizer"
 //+kubebuilder:rbac:groups=postgresql.lunar.tech,resources=postgresqlusers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=postgresql.lunar.tech,resources=postgresqlusers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=postgresql.lunar.tech,resources=postgresqlusers/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list
 
 func (r *PostgreSQLUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)


### PR DESCRIPTION
The controller needs access to secrets and config maps if resource references
are used by PostgreSQLDatabase or PostgreSQLUser resources. Currently if any of
these are used and the deafult role is used, the controller is unable to
reconsile.

This change adds the kubebuilder annotations to ensure the role is correct.