### PR TITLE
Add ARM64 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV # extracts the tag name from refs/tags/v1.2.3
 
       - name: "Build image"
-        run: make docker-build TAG=$RELEASE_VERSION
+        run: make docker-buildx-build TAG=$RELEASE_VERSION
 
       - name: "Docker login to Quay.io"
         env:
@@ -26,4 +26,4 @@ jobs:
         run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD quay.io
 
       - name: "Push image"
-        run: make docker-push TAG=$RELEASE_VERSION
+        run: make docker-buildx-push TAG=$RELEASE_VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,15 @@ jobs:
       - name: Set tag in environment
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV # extracts the tag name from refs/tags/v1.2.3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
       - name: "Build image"
         run: make docker-buildx-build TAG=$RELEASE_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager .
+RUN CGO_ENABLED=0 go build -a -o manager .
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT=postgresql-controller
 # Current Operator version
-VERSION ?= 0.0.33
+VERSION ?= 0.0.34
 # Image URL to use all building/pushing image targets
 ORG ?= lunarway
 REG ?= quay.io

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT=postgresql-controller
 # Current Operator version
-VERSION ?= 0.0.35
+VERSION ?= 0.0.33
 # Image URL to use all building/pushing image targets
 ORG ?= lunarway
 REG ?= quay.io

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT=postgresql-controller
 # Current Operator version
-VERSION ?= 0.0.34
+VERSION ?= 0.0.35
 # Image URL to use all building/pushing image targets
 ORG ?= lunarway
 REG ?= quay.io

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,7 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-docker-buildx-setup:
-	docker buildx inspect --bootstrap
-
-docker-buildx-build: test docker-buildx-setup
+docker-buildx-build: test
 	docker buildx build --platform=linux/amd64,linux/arm64 -t ${IMG} .
 
 docker-buildx-push: docker-buildx-build

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,15 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+docker-buildx-setup:
+	docker buildx inspect --bootstrap
+
+docker-buildx-build: test docker-buildx-setup
+	docker buildx build --platform=linux/amd64,linux/arm64 -t ${IMG} .
+
+docker-buildx-push: docker-buildx-build
+	docker buildx build --platform=linux/amd64,linux/arm64 -t ${IMG} --push .
+
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 


### PR DESCRIPTION
(Cc @Crevil)

This PR adds ARM support. It updates the `Makefile` to add `docker-buildx-build` and `docker-buildx-push` commands to build and push multiarch image manifests. It also updates the `release` GitHub Action to use these commands instead of `docker-build` and `docker-push`. This PR does not remove or modify the existing `docker-build` or `docker-push` make targets in order to avoid disrupting any developer workflows.

**NOTE**: This has been [tested](https://github.com/weberc2/postgresql-controller/runs/4436189526?check_suite_focus=true) up to the point of pushing the image to quay.io/lunarway/postgresql-controller (because I don't have credentials).

Closes #81.