### PR TITLE
Use fake.NewClientBuilder instead of NewFakeClient

### DIFF
--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -119,7 +119,9 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 		database2Resource,
 		userResource,
 	}
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().
+		WithRuntimeObjects(objs...).
+		Build()
 
 	// Create a controller object with the fake client but otherwise "live" setup
 	// with database interaction
@@ -238,7 +240,9 @@ func TestReconcile_rolePrefix(t *testing.T) {
 		database1Resource,
 		userResource,
 	}
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().
+		WithRuntimeObjects(objs...).
+		Build()
 
 	// Create a controller object with the fake client but otherwise "live" setup
 	// with database interaction
@@ -387,7 +391,9 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 		database2Resource,
 		userResource,
 	}
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().
+		WithRuntimeObjects(objs...).
+		Build()
 
 	// Create a controller object with the fake client but otherwise "live" setup
 	// with database interaction

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -108,7 +108,9 @@ func TestResourceValue(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewFakeClient(tc.objs...)
+			client := fake.NewClientBuilder().
+				WithRuntimeObjects(tc.objs...).
+				Build()
 
 			value, err := kube.ResourceValue(client, tc.resource, tc.namespace)
 
@@ -171,7 +173,9 @@ func TestSecretValue(t *testing.T) {
 			}
 
 			// Create a fake client to mock API calls.
-			cl := fake.NewFakeClient(objs...)
+			cl := fake.NewClientBuilder().
+				WithRuntimeObjects(objs...).
+				Build()
 
 			namespacedName := types.NamespacedName{
 				Name:      tc.secretName,
@@ -238,7 +242,9 @@ func TestConfigMapValue(t *testing.T) {
 			}
 
 			// Create a fake client to mock API calls.
-			cl := fake.NewFakeClient(objs...)
+			cl := fake.NewClientBuilder().
+				WithRuntimeObjects(objs...).
+				Build()
 
 			namespacedName := types.NamespacedName{
 				Name:      tc.configMapName,


### PR DESCRIPTION
Function fake.NewFakeClient is deprecated. This change migrates to the
fake.NewClientBuilder instead.