### PR TITLE
Handle passwords with special characters

### DIFF
--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -25,7 +26,7 @@ type ConnectionString struct {
 
 // Raw returns a PostgreSQL connection string.
 func (c ConnectionString) Raw() string {
-	raw := fmt.Sprintf("postgresql://%s:%s@%s", c.User, c.Password, c.Host)
+	raw := fmt.Sprintf("postgresql://%s:%s@%s", c.User, url.QueryEscape(c.Password), c.Host)
 	if c.Database != "" {
 		raw += fmt.Sprintf("/%s", c.Database)
 	}
@@ -45,7 +46,7 @@ func (c ConnectionString) String() string {
 	if c.Password == "" {
 		return raw
 	}
-	return strings.ReplaceAll(raw, c.Password, "********")
+	return strings.ReplaceAll(raw, url.QueryEscape(c.Password), "********")
 }
 
 func Connect(log logr.Logger, connectionString ConnectionString) (*sql.DB, error) {

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -86,16 +86,35 @@ func TestConnectionString_Raw(t *testing.T) {
 // TestConnectionString_String tests that ConnectionString does not expose
 // password for fmt.Stringer and fmt.Formatter
 func TestConnectionString_String(t *testing.T) {
-	connectionString := postgres.ConnectionString{
-		Host:     "host:5432",
-		Database: "database",
-		User:     "user",
-		Password: "12:34",
+	tt := []struct {
+		name     string
+		password string
+	}{
+		{
+			name:     "simple case",
+			password: "1234",
+		},
+		// Make sure that escaping passwords doesn't break password redaction.
+		{
+			name:     "special characters in password",
+			password: "12:34@56",
+		},
 	}
-	expected := "postgresql://user:********@host:5432/database?sslmode=disable"
-	assert.Equal(t, fmt.Sprintf("%s", connectionString), expected, "connection string not as expected") //nolint:gosimple
-	assert.Equal(t, fmt.Sprintf("%v", connectionString), expected, "connection string not as expected")
-	assert.Equal(t, expected, connectionString.String(), "connection string not as expected")
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			connectionString := postgres.ConnectionString{
+				Host:     "host:5432",
+				Database: "database",
+				User:     "user",
+				Password: tc.password,
+			}
+			expected := "postgresql://user:********@host:5432/database?sslmode=disable"
+			assert.Equal(t, fmt.Sprintf("%s", connectionString), expected, "connection string not as expected") //nolint:gosimple
+			assert.Equal(t, fmt.Sprintf("%v", connectionString), expected, "connection string not as expected")
+			assert.Equal(t, expected, connectionString.String(), "connection string not as expected")
+		})
+	}
 }
 
 // TestConnectionString_logger tests that ConnectionString does not expose

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -64,6 +64,16 @@ func TestConnectionString_Raw(t *testing.T) {
 			},
 			raw: "postgresql://user:1234@host:5432/database?sslmode=strict",
 		},
+		{
+			name: "special characters in password",
+			connectionString: postgres.ConnectionString{
+				Host:     "host:5432",
+				Database: "database",
+				User:     "user",
+				Password: "12:34",
+			},
+			raw: "postgresql://user:12%3A34@host:5432/database?sslmode=disable",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -80,7 +90,7 @@ func TestConnectionString_String(t *testing.T) {
 		Host:     "host:5432",
 		Database: "database",
 		User:     "user",
-		Password: "1234",
+		Password: "12:34",
 	}
 	expected := "postgresql://user:********@host:5432/database?sslmode=disable"
 	assert.Equal(t, fmt.Sprintf("%s", connectionString), expected, "connection string not as expected") //nolint:gosimple


### PR DESCRIPTION
Presently, the application interpolates the raw password input directly into a URL-formatted connection string (e.g., `postgres://user:${password}@host:port/dbname?...`); however, if this password contains a special character (for example, an `@` or `:`), the resulting query string will be invalid and the controller will error out when it tries to initiate a connection with the database. This PR escapes the password, allowing special characters to be handled correctly.

Without this change, users will have to URL-escape their passwords in YAML which may not be feasible in cases where passwords are being referenced from an existing Kubernetes secret (e.g., `PostgreSQLHostCredentials.Password` from #82/#90).