### PR TITLE
Fix bug with unknown PostgreSQLHostCredentials reference

### DIFF
--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -1,14 +1,25 @@
 package controllers
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/api/v1alpha1"
 	ctlerrors "go.lunarway.com/postgresql-controller/pkg/errors"
+	"go.lunarway.com/postgresql-controller/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestStatus_update(t *testing.T) {
@@ -146,4 +157,165 @@ func TestStatus_update(t *testing.T) {
 			assert.Equal(t, tc.after, tc.status.database, "database status not as expected")
 		})
 	}
+}
+
+// TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference tests that
+// a PostgreSQLDatabase resource can reference a PostgreSQLHostCredentials
+// resource.
+func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	host := test.Integration(t)
+	var (
+		epoch               = time.Now().UnixNano()
+		namespace           = "default"
+		databaseName        = fmt.Sprintf("database_%d", epoch)
+		hostCredentialsName = fmt.Sprintf("hostcredentials_%d", epoch)
+
+		credentialsResource = &lunarwayv1alpha1.PostgreSQLHostCredentials{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hostCredentialsName,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLHostCredentialsSpec{
+				Host: lunarwayv1alpha1.ResourceVar{
+					Value: "localhost",
+				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: "admin",
+				},
+				Password: lunarwayv1alpha1.ResourceVar{
+					Value: "password",
+				},
+			},
+		}
+
+		databaseResource = &lunarwayv1alpha1.PostgreSQLDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      databaseName,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Name:            databaseName,
+				HostCredentials: hostCredentialsName,
+				Password: lunarwayv1alpha1.ResourceVar{
+					Value: "123456",
+				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: databaseName,
+				},
+			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+			},
+		}
+	)
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(lunarwayv1alpha1.GroupVersion, databaseResource, credentialsResource, &lunarwayv1alpha1.PostgreSQLDatabaseList{})
+
+	// Add tracked objects to the fake client simulating their existence in a k8s
+	// cluster
+	objs := []runtime.Object{
+		databaseResource,
+		credentialsResource,
+	}
+	cl := fake.NewClientBuilder().
+		WithRuntimeObjects(objs...).
+		Build()
+
+	// Create a controller object with the fake client but otherwise "live" setup
+	// with database interaction
+	r := &PostgreSQLDatabaseReconciler{
+		Client:          cl,
+		Log:             ctrl.Log.WithName(t.Name()),
+		HostCredentials: nil,
+	}
+
+	// seed database into the postgres host
+	seededDatabase(t, host, databaseName)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      databaseName,
+			Namespace: namespace,
+		},
+	}
+	res, err := r.Reconcile(context.Background(), req)
+	assert.NoError(t, err, "reconciliation failed")
+	assert.Equal(t, reconcile.Result{
+		Requeue:      false,
+		RequeueAfter: 0,
+	}, res, "result not as expected")
+}
+
+// TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference
+// tests that references to an unknown host credentials resource will results in
+// a reconciliation error.
+func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	host := test.Integration(t)
+	var (
+		epoch        = time.Now().UnixNano()
+		namespace    = "default"
+		databaseName = fmt.Sprintf("database_%d", epoch)
+
+		databaseResource = &lunarwayv1alpha1.PostgreSQLDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      databaseName,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Name:            databaseName,
+				HostCredentials: "unknown",
+				Password: lunarwayv1alpha1.ResourceVar{
+					Value: "123456",
+				},
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: databaseName,
+				},
+			},
+			Status: lunarwayv1alpha1.PostgreSQLDatabaseStatus{
+				Phase: lunarwayv1alpha1.PostgreSQLDatabasePhaseRunning,
+			},
+		}
+	)
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(lunarwayv1alpha1.GroupVersion, databaseResource, &lunarwayv1alpha1.PostgreSQLDatabaseList{})
+
+	// Add tracked objects to the fake client simulating their existence in a k8s
+	// cluster
+	objs := []runtime.Object{
+		databaseResource,
+	}
+	cl := fake.NewClientBuilder().
+		WithRuntimeObjects(objs...).
+		Build()
+
+	// Create a controller object with the fake client but otherwise "live" setup
+	// with database interaction
+	r := &PostgreSQLDatabaseReconciler{
+		Client:          cl,
+		Log:             ctrl.Log.WithName(t.Name()),
+		HostCredentials: nil,
+	}
+
+	seededDatabase(t, host, databaseName)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      databaseName,
+			Namespace: namespace,
+		},
+	}
+	res, err := r.Reconcile(context.Background(), req)
+	assert.Error(t, err, "reconciliation failed")
+	assert.Equal(t, reconcile.Result{
+		Requeue:      false,
+		RequeueAfter: 0,
+	}, res, "result not as expected")
 }

--- a/main.go
+++ b/main.go
@@ -122,7 +122,6 @@ func main() {
 	if err = (&controllers.PostgreSQLDatabaseReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("PostgreSQLDatabase"),
-		Scheme: mgr.GetScheme(),
 
 		HostCredentials: config.HostCredentials,
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
Currently if a `PostgreSQLDatabase` references an unknown
`PostgreSQLHostCredentials` resource reconciliation is disabled. This is not
intended because the referenced resources might show up in the near future, eg.
it has to be unsealed. The bug is due to unknown references leading to an
`errors.Invalid` error which skips future reconciliations.

This change includes two integration tests of a `PostgreSQLHostCredentials`
reference in a `PostgreSQLDatabase` resource which validates the bug and fix. The
change also adds some additional logging to give insights into the decision
process along with cleaning up the error handling of said logic.

Lastly the Scheme field of the `PostgreSQLDatabaseReconciler` struct is removed as
it is unused.