### PR TITLE
Fix panic on PostgreSQLDatabase resource delete

### DIFF
--- a/controllers/postgresqldatabase_controller.go
+++ b/controllers/postgresqldatabase_controller.go
@@ -177,6 +177,10 @@ func (s *status) Persist(ctx context.Context, err error, log logr.Logger) {
 // update updates database reference based on its values and returns whether any
 // changes were written.
 func (s *status) update(err error) bool {
+	if s.database == nil {
+		return false
+	}
+
 	var errorMessage string
 	var phase postgresqlv1alpha1.PostgreSQLDatabasePhase
 	switch {

--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -37,6 +37,15 @@ func TestStatus_update(t *testing.T) {
 		after   *lunarwayv1alpha1.PostgreSQLDatabase
 	}{
 		{
+			name: "empty status",
+			status: status{
+				database: nil,
+			},
+			err:     nil,
+			changes: false,
+			after:   nil,
+		},
+		{
 			name: "new status",
 			status: status{
 				database: &lunarwayv1alpha1.PostgreSQLDatabase{


### PR DESCRIPTION
Currently if a `PostgreSQLDatabase` resource is removed the
`PostgreSQLDatabaseReconciler.reconcile` method will return early on the Not Found
error from the Kubernetes API. The `PostgreSQLDatabaseReconciler.Reconcile` method
will after this try to update the status of the resource which panics as it was
never found on the `status` value.

This change adds a guard on the `status.update` method which will make it safe to
do on non-existing resources and effectively make the update a noop. This fixes
the panic and ensures that the controller handles the deletion successfully.