### PR TITLE
Support dot characters in PostgreSQLUser spec.name

### DIFF
--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -177,9 +177,7 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr
 
 	// We need to sanitize the user.Spec.Name to be a valid PostgreSQL role name
 	// to allow emails containing '.' characters.
-	sanitizedUser := user.DeepCopy()
-	sanitizedName := strings.ReplaceAll(user.Spec.Name, ".", "_")
-	sanitizedUser.Spec.Name = sanitizedName
+	sanitizedUser := sanitizedUser(user)
 
 	// Error check in the bottom because we want aws policy to be set no matter what.
 	granterErr := r.Granter.SyncUser(reqLogger, request.Namespace, r.RolePrefix, *sanitizedUser)
@@ -191,7 +189,7 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr
 		MaxUsersPerPolicy: 30,
 		RolePrefix:        r.RolePrefix,
 		AWSLoginRoles:     r.AWSLoginRoles,
-	}, user.Spec.Name, sanitizedName)
+	}, user.Spec.Name, sanitizedUser.Spec.Name)
 
 	if granterErr != nil || awsPolicyErr != nil {
 		return ctrl.Result{}, fmt.Errorf("grantErr: %v, awsPolicyErr: %v", granterErr, awsPolicyErr)
@@ -210,4 +208,13 @@ func (r *PostgreSQLUserReconciler) finalizeUser(reqLogger logr.Logger, client *i
 	reqLogger.Info("Successfully finalized PostgreSQLUser")
 
 	return nil
+}
+
+func sanitizedUser(raw *postgresqlv1alpha1.PostgreSQLUser) *postgresqlv1alpha1.PostgreSQLUser {
+	sanitizedUser := raw.DeepCopy()
+
+	// remove characters not allowed in PostgreSQL roles
+	sanitizedUser.Spec.Name = strings.ReplaceAll(sanitizedUser.Spec.Name, ".", "_")
+
+	return sanitizedUser
 }

--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -46,7 +47,7 @@ type PostgreSQLUserReconciler struct {
 	Scheme *runtime.Scheme
 
 	Granter    grants.Granter
-	AddUser    func(client *iam.Client, config iam.AddUserConfig, username string) error
+	AddUser    func(client *iam.Client, config iam.AddUserConfig, username, rolename string) error
 	RemoveUser func(client *iam.Client, awsLoginRoles []string, username string) error
 
 	RolePrefix         string
@@ -174,8 +175,14 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr
 		}
 	}
 
+	// We need to sanitize the user.Spec.Name to be a valid PostgreSQL role name
+	// to allow emails containing '.' characters.
+	sanitizedUser := user.DeepCopy()
+	sanitizedName := strings.ReplaceAll(user.Spec.Name, ".", "_")
+	sanitizedUser.Spec.Name = sanitizedName
+
 	// Error check in the bottom because we want aws policy to be set no matter what.
-	granterErr := r.Granter.SyncUser(reqLogger, request.Namespace, r.RolePrefix, *user)
+	granterErr := r.Granter.SyncUser(reqLogger, request.Namespace, r.RolePrefix, *sanitizedUser)
 
 	awsPolicyErr := r.AddUser(client, iam.AddUserConfig{
 		PolicyBaseName:    r.AWSPolicyName,
@@ -184,7 +191,7 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr
 		MaxUsersPerPolicy: 30,
 		RolePrefix:        r.RolePrefix,
 		AWSLoginRoles:     r.AWSLoginRoles,
-	}, user.Spec.Name)
+	}, user.Spec.Name, sanitizedName)
 
 	if granterErr != nil || awsPolicyErr != nil {
 		return ctrl.Result{}, fmt.Errorf("grantErr: %v, awsPolicyErr: %v", granterErr, awsPolicyErr)

--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -176,7 +176,6 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr
 	}
 
 	// We need to sanitize the user.Spec.Name to be a valid PostgreSQL role name
-	// to allow emails containing '.' characters.
 	sanitizedUser := sanitizedUser(user)
 
 	// Error check in the bottom because we want aws policy to be set no matter what.
@@ -210,6 +209,7 @@ func (r *PostgreSQLUserReconciler) finalizeUser(reqLogger logr.Logger, client *i
 	return nil
 }
 
+// sanitizedUser removes characters that are not valid in PostgreSQL role names.
 func sanitizedUser(raw *postgresqlv1alpha1.PostgreSQLUser) *postgresqlv1alpha1.PostgreSQLUser {
 	sanitizedUser := raw.DeepCopy()
 

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -13,7 +13,7 @@ type AddUserConfig struct {
 	AWSLoginRoles     []string
 }
 
-func AddUser(client *Client, config AddUserConfig, username string) error {
+func AddUser(client *Client, config AddUserConfig, username, rolename string) error {
 
 	policies, err := client.ListPolicies()
 	if err != nil {
@@ -28,7 +28,7 @@ func AddUser(client *Client, config AddUserConfig, username string) error {
 
 	for _, policy := range policies {
 		if policy.Document.Count() < config.MaxUsersPerPolicy {
-			policy.Document.Add(config.Region, config.AccountID, config.RolePrefix, username)
+			policy.Document.Add(config.Region, config.AccountID, config.RolePrefix, username, rolename)
 			err := client.UpdatePolicy(policy)
 			return err
 		}
@@ -39,7 +39,7 @@ func AddUser(client *Client, config AddUserConfig, username string) error {
 		Document: &PolicyDocument{Version: "2012-10-17"},
 	}
 
-	newPolicy.Document.Add(config.Region, config.AccountID, config.RolePrefix, username)
+	newPolicy.Document.Add(config.Region, config.AccountID, config.RolePrefix, username, rolename)
 	newAwsPolicy, err := client.CreatePolicy(newPolicy)
 	if err != nil {
 		return err

--- a/pkg/iam/iam_test.go
+++ b/pkg/iam/iam_test.go
@@ -63,6 +63,7 @@ func Test_AddRemoveUser(t *testing.T) {
 		operation         string
 		existingUsers     []string
 		user              string
+		role              string
 		maxUsersPerPolicy int
 		policyCount       int
 		userCount         int
@@ -72,6 +73,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{},
 			user:              "jwr",
+			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         1,
@@ -81,6 +83,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{"jwr"},
 			user:              "jwr",
+			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         1,
@@ -90,6 +93,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{"kni"},
 			user:              "jwr",
+			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         2,
@@ -99,6 +103,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{"kni"},
 			user:              "jwr",
+			role:              "jwr",
 			maxUsersPerPolicy: 1,
 			policyCount:       2,
 			userCount:         2,
@@ -108,6 +113,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         RemoveUserOperation,
 			existingUsers:     []string{"kni", "jwr"},
 			user:              "kni",
+			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         1,
@@ -117,6 +123,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         RemoveUserOperation,
 			existingUsers:     []string{"kni", "jwr"},
 			user:              "who_dis",
+			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         2,
@@ -126,6 +133,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         RemoveUserOperation,
 			existingUsers:     []string{"kni"},
 			user:              "kni",
+			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       0,
 			userCount:         0,
@@ -214,7 +222,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			}
 
 			if tt.operation == AddUserOperation {
-				err = AddUser(client, config, tt.user)
+				err = AddUser(client, config, tt.user, tt.role)
 				assert.NoError(err)
 			} else if tt.operation == RemoveUserOperation {
 				err = RemoveUser(client, []string{awsLoginRole}, tt.user)

--- a/pkg/iam/iam_test.go
+++ b/pkg/iam/iam_test.go
@@ -63,7 +63,6 @@ func Test_AddRemoveUser(t *testing.T) {
 		operation         string
 		existingUsers     []string
 		user              string
-		role              string
 		maxUsersPerPolicy int
 		policyCount       int
 		userCount         int
@@ -73,7 +72,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{},
 			user:              "jwr",
-			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         1,
@@ -83,7 +81,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{"jwr"},
 			user:              "jwr",
-			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         1,
@@ -93,7 +90,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{"kni"},
 			user:              "jwr",
-			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         2,
@@ -103,7 +99,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         AddUserOperation,
 			existingUsers:     []string{"kni"},
 			user:              "jwr",
-			role:              "jwr",
 			maxUsersPerPolicy: 1,
 			policyCount:       2,
 			userCount:         2,
@@ -113,7 +108,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         RemoveUserOperation,
 			existingUsers:     []string{"kni", "jwr"},
 			user:              "kni",
-			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         1,
@@ -123,7 +117,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         RemoveUserOperation,
 			existingUsers:     []string{"kni", "jwr"},
 			user:              "who_dis",
-			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       1,
 			userCount:         2,
@@ -133,7 +126,6 @@ func Test_AddRemoveUser(t *testing.T) {
 			operation:         RemoveUserOperation,
 			existingUsers:     []string{"kni"},
 			user:              "kni",
-			role:              "jwr",
 			maxUsersPerPolicy: 2,
 			policyCount:       0,
 			userCount:         0,
@@ -222,7 +214,7 @@ func Test_AddRemoveUser(t *testing.T) {
 			}
 
 			if tt.operation == AddUserOperation {
-				err = AddUser(client, config, tt.user, tt.role)
+				err = AddUser(client, config, tt.user, tt.user)
 				assert.NoError(err)
 			} else if tt.operation == RemoveUserOperation {
 				err = RemoveUser(client, []string{awsLoginRole}, tt.user)

--- a/pkg/iam/policy.go
+++ b/pkg/iam/policy.go
@@ -50,12 +50,12 @@ func (p *PolicyDocument) Count() int {
 	return len(p.Statement)
 }
 
-func (p *PolicyDocument) Add(region, accountID, rolePrefix, username string) {
+func (p *PolicyDocument) Add(region, accountID, rolePrefix, username, rolename string) {
 	awsUserID := usernameToUserId(username)
 	statementEntry := StatementEntry{
 		Effect:    "Allow",
 		Action:    []string{"rds-db:connect"},
-		Resource:  []string{fmt.Sprintf("arn:aws:rds-db:%s:%s:dbuser:*/%s%s", region, accountID, rolePrefix, username)},
+		Resource:  []string{fmt.Sprintf("arn:aws:rds-db:%s:%s:dbuser:*/%s%s", region, accountID, rolePrefix, rolename)},
 		Condition: StringLike{StringLike: UserID{AWSUserID: awsUserID}},
 	}
 	p.Statement = append(p.Statement, statementEntry)

--- a/pkg/iam/policy_test.go
+++ b/pkg/iam/policy_test.go
@@ -17,11 +17,12 @@ func Test_AddUsersToDocument(t *testing.T) {
 	assert := assert.New(t)
 
 	document := NewPolicyDocument("2012-10-17")
-	document.Add(region, accountID, rolePrefix, "user1")
-	document.Add(region, accountID, rolePrefix, "user2")
+	document.Add(region, accountID, rolePrefix, "user1", "role1")
+	document.Add(region, accountID, rolePrefix, "user2", "role2")
 
 	assert.Equal(2, document.Count())
 	assert.True(document.Exists("user1"))
+	assert.Equal("arn:aws:rds-db:eu-west-1:000000000000:dbuser:*/iam_developer_role1", document.Statement[0].Resource[0])
 	assert.True(document.Exists("user2"))
 }
 
@@ -30,9 +31,9 @@ func Test_RemoveUsersFromDocument(t *testing.T) {
 	assert := assert.New(t)
 
 	document := NewPolicyDocument("2012-10-17")
-	document.Add(region, accountID, rolePrefix, "user1")
-	document.Add(region, accountID, rolePrefix, "user2")
-	document.Add(region, accountID, rolePrefix, "user3")
+	document.Add(region, accountID, rolePrefix, "user1", "role1")
+	document.Add(region, accountID, rolePrefix, "user2", "role2")
+	document.Add(region, accountID, rolePrefix, "user3", "role3")
 	document.Remove("user2")
 
 	assert.Equal(2, document.Count())

--- a/pkg/iam/policy_test.go
+++ b/pkg/iam/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -20,7 +21,7 @@ func Test_AddUsersToDocument(t *testing.T) {
 	document.Add(region, accountID, rolePrefix, "user1", "role1")
 	document.Add(region, accountID, rolePrefix, "user2", "role2")
 
-	assert.Equal(2, document.Count())
+	require.Equal(t, 2, document.Count())
 	assert.True(document.Exists("user1"))
 	assert.Equal("arn:aws:rds-db:eu-west-1:000000000000:dbuser:*/iam_developer_role1", document.Statement[0].Resource[0])
 	assert.True(document.Exists("user2"))


### PR DESCRIPTION
Currently the spec.name field is mapped to both the AWS user email and
postgresql role name. This model is not correct as emails might contain "."
(dot) characters but these are not allowed in PostgreSQL roles.

This change updates our model to separate these concerns. A sanitized version of
the field is then used for the role while the original field is used as the
email.