### PR TITLE
Only run release from default branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: github.event.base_ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1


### PR DESCRIPTION
Currently, the release action will run on a new tag from any branch which is not great.

This change adds a condition to only run when it is the default branch which gets a new tag