### PR TITLE
Remove check for which branch release is made from

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    # only allow tags on the master branch
-    if: github.event.release.target_commitish == 'master'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
The latest release workflow failed: https://github.com/lunarway/postgresql-controller/releases/tag/v0.3.2.

This change fixes the workflow so a new release can be made. 