### PR TITLE
Add proper requeue strategy for database resources

### DIFF
--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -261,7 +261,7 @@ func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testin
 
 // TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference
 // tests that references to an unknown host credentials resource will results in
-// a reconciliation error.
+// a requeued reconciliation.
 func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -322,9 +322,9 @@ func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t 
 		},
 	}
 	res, err := r.Reconcile(context.Background(), req)
-	assert.Error(t, err, "reconciliation failed")
+	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{
 		Requeue:      false,
-		RequeueAfter: 0,
+		RequeueAfter: 10 * time.Second,
 	}, res, "result not as expected")
 }


### PR DESCRIPTION
Currently if an error happens during reconciliation of a PostgreSQLDatabase
resource we log an error log with the error. This is noisy and not really an
error in the controller but wrong usage from the client.

Further more we never retry any errors automatically before an update is caused
which makes turn around time for eg. a secret appearing longer.

This change updates the Reconcile method to select a proper strategy based on
errors to know when to retry. It also stops returning errors to the controller
manager which avoids error logs from it. Overall we get reduced error logs and
better reconciliation handling.

Closes #181 