### PR TITLE
Use Go 1.19 in actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.17.7"
+          go-version: "1.19.0"
 
       - name: Cache Go modules
         uses: actions/cache@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          go-version: "1.19.0"
 
       - name: Set tag in environment
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV # extracts the tag name from refs/tags/v1.2.3

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the postgresql.lunar.tech v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=postgresql.lunar.tech
+// +kubebuilder:object:generate=true
+// +groupName=postgresql.lunar.tech
 package v1alpha1
 
 import (


### PR DESCRIPTION
Currently we have Docker images with 1.19 and CI/CD is building with 1.17.7.

This change updates the actions to use the right version.