### PR TITLE
Use deterministic version of localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
   aws:
-    image: localstack/localstack
+    image: localstack/localstack:1.3.1
     environment:
       - SERVICES=iam
     ports:


### PR DESCRIPTION
This change modifies the docker compose file to use  a deterministic tag for the `localstack/localstack` dependency.