### PR TITLE
Do not return error if error is of a type we can recover from

### DIFF
--- a/pkg/iam/client.go
+++ b/pkg/iam/client.go
@@ -321,9 +321,9 @@ func (c *Client) updatePolicy(policy *Policy, svc *iam.IAM) error {
 			if err != nil {
 				return fmt.Errorf("create policy version: %s: %w", policy.Name, err)
 			}
+		} else {
+			return fmt.Errorf("create policy version with arn: %s: %w", arn, err)
 		}
-
-		return fmt.Errorf("create policy version with arn %s: %w", arn, err)
 	}
 
 	return nil


### PR DESCRIPTION
Currently, the `updatePolicy` function will return an error with the prefix `create policy version with arn` even though the error was recoverable.

This change adds an else branch to the code to only return that error if the above `if` condition is not hit.

Example log: `grantErr: <nil>, awsPolicyErr: policy '<policy>': create policy version: <policy name>: create policy version with arn <arn>: %!w(<nil>)`