### PR TITLE
Add longer timeout to ensure lint does not fail

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,3 +17,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
+        with:
+          args: --timeout=5m


### PR DESCRIPTION
Should fix timeout issues that often occur.