### PR TITLE
Fix/iam duplicate creation

### DIFF
--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -27,8 +27,6 @@ func EnsureUser(client *Client, config EnsureUserConfig, userName, rolename stri
 		usersInPolicy := policy.Document.ListUsers()
 		for _, user := range usersInPolicy {
 			users[user] = struct{}{}
-			fmt.Printf("Found user: %s\n", user)
-			fmt.Printf("current user: %s\n", userName)
 		}
 	}
 

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -65,7 +65,7 @@ func EnsureUser(client *Client, config EnsureUserConfig, userName, rolename stri
 		}
 	}
 
-	// User could not be added to an existing policy so we create a new one instead.
+	// User could not be handled in an existing policy so we create a new one instead.
 	if !userHandled {
 		fmt.Print("Creating new policy\n")
 		// TODO : There is a bug where where the new name might exist. This could for instance be the case where a policy i is deleted but i+1 exists. Then len(policies) = i+1 and there is a clash.

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -65,7 +65,6 @@ func EnsureUser(client *Client, config EnsureUserConfig, userName, rolename stri
 
 	// User could not be handled in an existing policy so we create a new one instead.
 	if !userHandled {
-		fmt.Print("Creating new policy\n")
 		// TODO : There is a bug where where the new name might exist. This could for instance be the case where a policy i is deleted but i+1 exists. Then len(policies) = i+1 and there is a clash.
 		newPolicy := &Policy{
 			Name:     fmt.Sprintf("%s_%d", config.PolicyBaseName, len(policies)),

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -16,41 +16,65 @@ type EnsureUserConfig struct {
 	AWSLoginRoles     []string
 }
 
-func EnsureUser(client *Client, config EnsureUserConfig, username, rolename string) error {
+func EnsureUser(client *Client, config EnsureUserConfig, userName, rolename string) error {
+	users := make(map[string]struct{})
 	policies, err := client.ListPolicies()
 	if err != nil {
 		return err
 	}
 
-	userIsInPolicy := false
 	for _, policy := range policies {
-		// try to update to see if the policy is managing the user already
-		updated := policy.Document.Update(config.Region, config.AccountID, config.RolePrefix, username, rolename)
-		if updated {
-			err = updatePolicies(client, policies)
-			if err != nil {
-				return err
-			}
-
-			userIsInPolicy = true
-		} else if policy.Document.Count() < config.MaxUsersPerPolicy {
-			policy.Document.Add(config.Region, config.AccountID, config.RolePrefix, username, rolename)
-			err = updatePolicies(client, policies)
-			if err != nil {
-				return err
-			}
-
-			userIsInPolicy = true
+		usersInPolicy := policy.Document.ListUsers()
+		for _, user := range usersInPolicy {
+			users[user] = struct{}{}
+			fmt.Printf("Found user: %s\n", user)
+			fmt.Printf("current user: %s\n", userName)
 		}
 	}
 
-	if !userIsInPolicy {
+	userHandled := false
+	if _, ok := users[userName]; ok {
+		for _, policy := range policies {
+			if !policy.Document.Exists(userName) {
+				break
+			}
+
+			// Try to update the document where the user is present to ensure correct roleName.
+			updated := policy.Document.Update(config.Region, config.AccountID, config.RolePrefix, userName, rolename)
+			if updated {
+				err = updatePolicies(client, policies)
+				if err != nil {
+					return err
+				}
+			}
+
+			userHandled = true
+		}
+		// If the user does not exists, then see if we can find room in an existing policy document
+	} else {
+		for _, policy := range policies {
+			if policy.Document.Count() < config.MaxUsersPerPolicy {
+				policy.Document.Add(config.Region, config.AccountID, config.RolePrefix, userName, rolename)
+				err = updatePolicies(client, policies)
+				if err != nil {
+					return err
+				}
+
+				userHandled = true
+			}
+		}
+	}
+
+	// User could not be added to an existing policy so we create a new one instead.
+	if !userHandled {
+		fmt.Print("Creating new policy\n")
+		// TODO : There is a bug where where the new name might exist. This could for instance be the case where a policy i is deleted but i+1 exists. Then len(policies) = i+1 and there is a clash.
 		newPolicy := &Policy{
 			Name:     fmt.Sprintf("%s_%d", config.PolicyBaseName, len(policies)),
 			Document: &PolicyDocument{Version: "2012-10-17"},
 		}
 
-		newPolicy.Document.Add(config.Region, config.AccountID, config.RolePrefix, username, rolename)
+		newPolicy.Document.Add(config.Region, config.AccountID, config.RolePrefix, userName, rolename)
 		newAwsPolicy, err := client.CreatePolicy(newPolicy)
 		if err != nil {
 			return err
@@ -110,7 +134,6 @@ func updatePolicies(client *Client, policies []*Policy) error {
 }
 
 func RemoveUser(client *Client, awsLoginRoles []string, username string) error {
-
 	policies, err := client.ListPolicies()
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, is is possible for a user to be added multiple times to different `iam policies`. This can happen after a another user is removed from a policy and the existing implementation then tries to add the user to that document even though it might already be present in another document.

This change introduces a check so we only add a user once. If it is already present somewhere in the list, then we now only try to update that specific document.