### PR TITLE
Continue instead of break

### DIFF
--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -34,7 +34,7 @@ func EnsureUser(client *Client, config EnsureUserConfig, userName, rolename stri
 	if _, ok := users[userName]; ok {
 		for _, policy := range policies {
 			if !policy.Document.Exists(userName) {
-				break
+				continue
 			}
 
 			// Try to update the document where the user is present to ensure correct roleName.


### PR DESCRIPTION
Currently, if a user is not present in the first policy, then the `break` statement will escape the `for range` part of the code, causing `userHandled` to always be false, causing a new policy to be created.

This change makes sure to use `continue` instead to be iterate to the next policy.