### PR TITLE
dep: patchesStrategicMerge deprecation

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - bases/postgresql.lunar.tech_postgresqlhostcredentials.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_postgresqldatabases.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.


### PR DESCRIPTION
fixing `patchesStrategicMerge` by replacing it with `patches` which takes its place