### PR TITLE
Management role

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,7 +48,6 @@ func (c *controllerConfiguration) RegisterFlags(flagSet *pflag.FlagSet) {
 	flagSet.DurationVar(&c.ResyncPeriod, "resync-period", 10*time.Hour, "determines the minimum frequency at which watched resources are reconciled")
 
 	flagSet.Var(&hostCredentials{value: &c.HostCredentials}, "host-credentials", "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
-	// TODO: Decide on a postgres role manager role name.
 	flagSet.StringVar(&c.ManagerRoleName, "manager-role-name", "postgres_role_manager", "Name of the role which will be managing other roles")
 	flagSet.StringSliceVar(&c.UserRoles, "user-roles", []string{"rds_iam"}, "List of roles granted to all users")
 	flagSet.BoolVar(&c.AllDatabasesReadEnabled, "all-databases-enabled-read", false, "Enable usage of allDatabases field in read access requests")

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type controllerConfiguration struct {
 	UserRolePrefix           string
 	AWS                      awsConfig
 	HostCredentials          map[string]postgres.Credentials
+	ManagerRoleName          string
 	AllDatabasesReadEnabled  bool
 	AllDatabasesWriteEnabled bool
 	ExtendedWriteEnabled     bool
@@ -47,6 +48,8 @@ func (c *controllerConfiguration) RegisterFlags(flagSet *pflag.FlagSet) {
 	flagSet.DurationVar(&c.ResyncPeriod, "resync-period", 10*time.Hour, "determines the minimum frequency at which watched resources are reconciled")
 
 	flagSet.Var(&hostCredentials{value: &c.HostCredentials}, "host-credentials", "Host and credential pairs in the form hostname=user:password. Use comma separated pairs for multiple hosts")
+	// TODO: Decide on a postgres role manager role name.
+	flagSet.StringVar(&c.ManagerRoleName, "manager-role-name", "postgres_role_manager", "Name of the role which will be managing other roles")
 	flagSet.StringSliceVar(&c.UserRoles, "user-roles", []string{"rds_iam"}, "List of roles granted to all users")
 	flagSet.BoolVar(&c.AllDatabasesReadEnabled, "all-databases-enabled-read", false, "Enable usage of allDatabases field in read access requests")
 	flagSet.BoolVar(&c.AllDatabasesWriteEnabled, "all-databases-enabled-write", false, "Enable usage of allDatabases field in write access requests")

--- a/controllers/postgresqldatabase_controller.go
+++ b/controllers/postgresqldatabase_controller.go
@@ -134,8 +134,9 @@ func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, reqLogger 
 		ctx,
 		reqLogger,
 		&EnsureParams{
-			Host:  host,
-			Admin: *adminCredentials,
+			Host:        host,
+			Admin:       *adminCredentials,
+			ManagerRole: r.ManagerRoleName,
 			Target: postgres.Credentials{
 				Name:     database.Spec.Name,
 				User:     user,
@@ -247,6 +248,8 @@ type EnsureParams struct {
 	// Admin holds the administrator credentials for the database instance.
 	Admin postgres.Credentials
 
+	ManagerRole string
+
 	// Target contains the credentials for the Postgres database that we intend
 	// to create.
 	Target postgres.Credentials
@@ -270,7 +273,7 @@ func (r *PostgreSQLDatabaseReconciler) EnsurePostgreSQLDatabase(ctx context.Cont
 			log.Error(err, "failed to close database connection", "host", params.Host, "database", "postgres", "user", params.Admin.Name)
 		}
 	}()
-	err = postgres.Database(log, db, params.Host, params.Target, r.ManagerRoleName)
+	err = postgres.Database(log, db, params.Host, params.Target, params.ManagerRole)
 	if err != nil {
 		return fmt.Errorf("create database %s on host %s: %w", params.Target.Name, connectionString, err)
 	}

--- a/controllers/postgresqldatabase_controller.go
+++ b/controllers/postgresqldatabase_controller.go
@@ -43,6 +43,7 @@ type PostgreSQLDatabaseReconciler struct {
 	client.Client
 	Log logr.Logger
 
+	ManagerRoleName string
 	// contains a map of credentials for hosts
 	HostCredentials map[string]postgres.Credentials
 }
@@ -269,7 +270,7 @@ func (r *PostgreSQLDatabaseReconciler) EnsurePostgreSQLDatabase(ctx context.Cont
 			log.Error(err, "failed to close database connection", "host", params.Host, "database", "postgres", "user", params.Admin.Name)
 		}
 	}()
-	err = postgres.Database(log, db, params.Host, params.Target)
+	err = postgres.Database(log, db, params.Host, params.Target, r.ManagerRoleName)
 	if err != nil {
 		return fmt.Errorf("create database %s on host %s: %w", params.Target.Name, connectionString, err)
 	}

--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -240,6 +240,7 @@ func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testin
 	r := &PostgreSQLDatabaseReconciler{
 		Client:          cl,
 		Log:             ctrl.Log.WithName(t.Name()),
+		ManagerRoleName: managerRoleName,
 		HostCredentials: nil,
 	}
 

--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -180,6 +180,7 @@ func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testin
 		namespace           = "default"
 		databaseName        = fmt.Sprintf("database_%d", epoch)
 		hostCredentialsName = fmt.Sprintf("hostcredentials_%d", epoch)
+		managerRoleName     = "postgres_role_manager"
 
 		credentialsResource = &lunarwayv1alpha1.PostgreSQLHostCredentials{
 			ObjectMeta: metav1.ObjectMeta{
@@ -243,7 +244,7 @@ func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testin
 	}
 
 	// seed database into the postgres host
-	seededDatabase(t, host, databaseName, databaseName)
+	seededDatabase(t, host, databaseName, databaseName, managerRoleName)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -267,9 +268,10 @@ func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t 
 
 	host := test.Integration(t)
 	var (
-		epoch        = time.Now().UnixNano()
-		namespace    = "default"
-		databaseName = fmt.Sprintf("database_%d", epoch)
+		epoch           = time.Now().UnixNano()
+		namespace       = "default"
+		databaseName    = fmt.Sprintf("database_%d", epoch)
+		managerRoleName = "postgres_role_manager"
 
 		databaseResource = &lunarwayv1alpha1.PostgreSQLDatabase{
 			ObjectMeta: metav1.ObjectMeta{
@@ -313,7 +315,7 @@ func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t 
 		HostCredentials: nil,
 	}
 
-	seededDatabase(t, host, databaseName, databaseName)
+	seededDatabase(t, host, databaseName, databaseName, managerRoleName)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -180,7 +180,7 @@ func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testin
 		namespace           = "default"
 		databaseName        = fmt.Sprintf("database_%d", epoch)
 		hostCredentialsName = fmt.Sprintf("hostcredentials_%d", epoch)
-		managerRoleName     = "postgres_role_manager"
+		managerRole         = "postgres_role_manager"
 
 		credentialsResource = &lunarwayv1alpha1.PostgreSQLHostCredentials{
 			ObjectMeta: metav1.ObjectMeta{
@@ -240,12 +240,12 @@ func TestPostgreSQLDatabase_Reconcile_hostCredentialsResourceReference(t *testin
 	r := &PostgreSQLDatabaseReconciler{
 		Client:          cl,
 		Log:             ctrl.Log.WithName(t.Name()),
-		ManagerRoleName: managerRoleName,
+		ManagerRoleName: managerRole,
 		HostCredentials: nil,
 	}
 
 	// seed database into the postgres host
-	seededDatabase(t, host, databaseName, databaseName, managerRoleName)
+	seededDatabase(t, host, databaseName, databaseName, managerRole)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -269,10 +269,10 @@ func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t 
 
 	host := test.Integration(t)
 	var (
-		epoch           = time.Now().UnixNano()
-		namespace       = "default"
-		databaseName    = fmt.Sprintf("database_%d", epoch)
-		managerRoleName = "postgres_role_manager"
+		epoch        = time.Now().UnixNano()
+		namespace    = "default"
+		databaseName = fmt.Sprintf("database_%d", epoch)
+		managerRole  = "postgres_role_manager"
 
 		databaseResource = &lunarwayv1alpha1.PostgreSQLDatabase{
 			ObjectMeta: metav1.ObjectMeta{
@@ -316,7 +316,7 @@ func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t 
 		HostCredentials: nil,
 	}
 
-	seededDatabase(t, host, databaseName, databaseName, managerRoleName)
+	seededDatabase(t, host, databaseName, databaseName, managerRole)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -89,7 +89,7 @@ func (r *PostgreSQLUserReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *PostgreSQLUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&postgresqlv1alpha1.PostgreSQLUser{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // explicitly set to 1 (which is also the default) because our reconciliation process is not necessarily concurrency safe.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). //explicitly set to 1 (which is also the default) because our reconciliation process is not necessarily concurrency safe.
 		Complete(r)
 }
 
@@ -203,6 +203,7 @@ func (r *PostgreSQLUserReconciler) getCredentials() *credentials.Credentials {
 }
 
 func (r *PostgreSQLUserReconciler) finalizeUser(reqLogger logr.Logger, client *iam.Client, user *postgresqlv1alpha1.PostgreSQLUser) error {
+
 	err := r.RemoveIAMUser(client, r.AWSLoginRoles, user.Spec.Name)
 	if err != nil {
 		return err

--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -89,7 +89,7 @@ func (r *PostgreSQLUserReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *PostgreSQLUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&postgresqlv1alpha1.PostgreSQLUser{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). //explicitly set to 1 (which is also the default) because our reconciliation process is not necessarily concurrency safe.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // explicitly set to 1 (which is also the default) because our reconciliation process is not necessarily concurrency safe.
 		Complete(r)
 }
 
@@ -203,7 +203,6 @@ func (r *PostgreSQLUserReconciler) getCredentials() *credentials.Credentials {
 }
 
 func (r *PostgreSQLUserReconciler) finalizeUser(reqLogger logr.Logger, client *iam.Client, user *postgresqlv1alpha1.PostgreSQLUser) error {
-
 	err := r.RemoveIAMUser(client, r.AWSLoginRoles, user.Spec.Name)
 	if err != nil {
 		return err

--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -40,12 +40,12 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 
 	host := test.Integration(t)
 	var (
-		epoch           = time.Now().UnixNano()
-		namespace       = "default"
-		database1Name   = fmt.Sprintf("database1_%d", epoch)
-		database2Name   = fmt.Sprintf("database2_%d", epoch)
-		userName        = fmt.Sprintf("service_user_%d", epoch)
-		managerRoleName = "postgres_role_manager"
+		epoch         = time.Now().UnixNano()
+		namespace     = "default"
+		database1Name = fmt.Sprintf("database1_%d", epoch)
+		database2Name = fmt.Sprintf("database2_%d", epoch)
+		userName      = fmt.Sprintf("service_user_%d", epoch)
+		managerRole   = "postgres_role_manager"
 
 		// user requesting access to all databases on host
 		userResource = &lunarwayv1alpha1.PostgreSQLUser{
@@ -156,7 +156,7 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 	}
 
 	// seed database1 into the postgres host
-	seededDatabase(t, host, database1Name, userName, managerRoleName)
+	seededDatabase(t, host, database1Name, userName, managerRole)
 
 	// reconcile user requesting access to all databases with a bad database
 	// reference
@@ -179,12 +179,12 @@ func TestReconcile_rolePrefix(t *testing.T) {
 
 	host := test.Integration(t)
 	var (
-		epoch           = time.Now().UnixNano()
-		namespace       = "default"
-		database1Name   = fmt.Sprintf("database1_%d", epoch)
-		userName        = fmt.Sprintf("user_%d", epoch)
-		rolePrefix      = "iam_developer_"
-		managerRoleName = "postgres_role_manager"
+		epoch         = time.Now().UnixNano()
+		namespace     = "default"
+		database1Name = fmt.Sprintf("database1_%d", epoch)
+		userName      = fmt.Sprintf("user_%d", epoch)
+		rolePrefix    = "iam_developer_"
+		managerRole   = "postgres_role_manager"
 
 		// user requesting access to all databases on host
 		userResource = &lunarwayv1alpha1.PostgreSQLUser{
@@ -274,7 +274,7 @@ func TestReconcile_rolePrefix(t *testing.T) {
 	}
 
 	// seed database1 into the postgres host
-	seededDatabase(t, host, database1Name, database1Name, managerRoleName)
+	seededDatabase(t, host, database1Name, database1Name, managerRole)
 
 	// reconcile user requesting access to all databases with a bad database
 	// reference
@@ -304,7 +304,7 @@ func TestReconcile_dotInName(t *testing.T) {
 		database1Name     = fmt.Sprintf("database1_%d", epoch)
 		userName          = fmt.Sprintf("user.%d", epoch)
 		userNameSanitized = fmt.Sprintf("user_%d", epoch)
-		managerRoleName   = "postgres_role_manager"
+		managerRole       = "postgres_role_manager"
 
 		// user requesting access to all databases on host
 		userResource = &lunarwayv1alpha1.PostgreSQLUser{
@@ -396,7 +396,7 @@ func TestReconcile_dotInName(t *testing.T) {
 	}
 
 	// seed database1 into the postgres host
-	seededDatabase(t, host, database1Name, database1Name, managerRoleName)
+	seededDatabase(t, host, database1Name, database1Name, managerRole)
 
 	// reconcile user requesting access to all databases with a bad database
 	// reference
@@ -427,12 +427,12 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 
 	host := test.Integration(t)
 	var (
-		epoch           = time.Now().UnixNano()
-		namespace       = "default"
-		database1Name   = fmt.Sprintf("database1_%d", epoch)
-		database2Name   = fmt.Sprintf("database2_%d", epoch)
-		userName        = fmt.Sprintf("user_%d", epoch)
-		managerRoleName = "postgres_role_manager"
+		epoch         = time.Now().UnixNano()
+		namespace     = "default"
+		database1Name = fmt.Sprintf("database1_%d", epoch)
+		database2Name = fmt.Sprintf("database2_%d", epoch)
+		userName      = fmt.Sprintf("user_%d", epoch)
+		managerRole   = "postgres_role_manager"
 
 		// user requesting access to all databases on host
 		userResource = &lunarwayv1alpha1.PostgreSQLUser{
@@ -543,8 +543,8 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 	}
 
 	// seed database1 into the postgres host
-	seededDatabase(t, host, database1Name, database1Name, managerRoleName)
-	seededDatabase(t, host, database2Name, database2Name, managerRoleName)
+	seededDatabase(t, host, database1Name, database1Name, managerRole)
+	seededDatabase(t, host, database2Name, database2Name, managerRole)
 
 	// reconcile user requesting access to all databases with a bad database
 	// reference
@@ -563,7 +563,7 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 
 // seededDatabase creates a database with name along with a 'movies' table owned
 // by the database role.
-func seededDatabase(t *testing.T, host, databaseName, userName string, managerRoleName string) {
+func seededDatabase(t *testing.T, host, databaseName, userName string, managerRole string) {
 	t.Helper()
 
 	dbConn, err := postgres.Connect(logf.Log, postgres.ConnectionString{
@@ -575,14 +575,14 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 	require.NoErrorf(t, err, "failed to connect to database host to seed database '%s'", databaseName)
 
 	// Create the ManagmentRole
-	err = createManagerRole(logf.Log, dbConn, managerRoleName)
+	err = createManagerRole(logf.Log, dbConn, managerRole)
 	require.NoErrorf(t, err, "failed to create managerRole for dbConn during seedDatabase")
 
 	err = postgres.Database(logf.Log, dbConn, host, postgres.Credentials{
 		Name:     databaseName,
 		Password: databaseName,
 		User:     userName,
-	}, managerRoleName)
+	}, managerRole)
 	require.NoErrorf(t, err, "failed to created seeded database '%s'", databaseName)
 
 	db1Conn, err := postgres.Connect(logf.Log, postgres.ConnectionString{

--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -574,16 +574,16 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 	})
 	require.NoErrorf(t, err, "failed to connect to database host to seed database '%s'", databaseName)
 
+	// Create the ManagmentRole
+	err = createManagerRole(logf.Log, dbConn, managerRoleName)
+	require.NoErrorf(t, err, "failed to create managerRole for dbConn during seedDatabase")
+
 	err = postgres.Database(logf.Log, dbConn, host, postgres.Credentials{
 		Name:     databaseName,
 		Password: databaseName,
 		User:     userName,
 	}, managerRoleName)
 	require.NoErrorf(t, err, "failed to created seeded database '%s'", databaseName)
-
-	// Create the ManagmentRole
-	err = createManagerRole(logf.Log, dbConn, managerRoleName)
-	require.NoErrorf(t, err, "failed to create managerRole for dbConn during seedDatabase")
 
 	db1Conn, err := postgres.Connect(logf.Log, postgres.ConnectionString{
 		Database: databaseName,

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("PostgreSQLDatabase"),
 
+		ManagerRoleName: config.ManagerRoleName,
 		HostCredentials: config.HostCredentials,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PostgreSQLDatabase")

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -55,12 +55,12 @@ func ParseUsernamePassword(s string) (Credentials, error) {
 // Database ensures that a user with provided password exists on the host and
 // that read and readwrite roles are created with default priviledges on a
 // schema named after the database name.
-func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials, managementRole string) error {
+func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials, managerRole string) error {
 	if host == "" {
 		return fmt.Errorf("host is required")
 	}
-	if managementRole == "" {
-		return fmt.Errorf("managementRole required")
+	if managerRole == "" {
+		return fmt.Errorf("managerRole required")
 	}
 	err := credentials.Validate()
 	if err != nil {
@@ -89,14 +89,15 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials,
 		}
 	}
 
-	// TODO: idempotentExec works, but it should probably be refactored for this purpose as well.
-	err = idempotentExec(log, db, idempotentExecReq{
+	// Grant the service user role to the managerRole WITH ADMIN OPTION
+	// This allows the managerRole to act on behalf of the service user
+	err = tryExec(log, db, tryExecReq{
 		objectType: "service role",
 		errorCode:  "undefined_object",
-		query:      fmt.Sprintf("GRANT %s TO %s WITH ADMIN OPTION", credentials.Name, managementRole),
+		query:      fmt.Sprintf("GRANT %s TO %s WITH ADMIN OPTION", credentials.Name, managerRole),
 	})
 	if err != nil {
-		return fmt.Errorf("grant %s to management role %s: %w", credentials.Name, managementRole, err)
+		return fmt.Errorf("grant %s to management role %s: %w", credentials.Name, managerRole, err)
 	}
 
 	// Create read and readwrite roles that can be used to grant users access to
@@ -205,7 +206,7 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials,
 
 func createUser(log logr.Logger, db *sql.DB, user, password string) error {
 	log = log.WithValues("user", user)
-	return idempotentExec(log, db, idempotentExecReq{
+	return tryExec(log, db, tryExecReq{
 		objectType: "service user",
 		errorCode:  "duplicate_object",
 		query:      fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'", user, password),
@@ -214,7 +215,7 @@ func createUser(log logr.Logger, db *sql.DB, user, password string) error {
 
 func createDatabase(log logr.Logger, db *sql.DB, name string) error {
 	log = log.WithValues("database", name)
-	return idempotentExec(log, db, idempotentExecReq{
+	return tryExec(log, db, tryExecReq{
 		objectType: "database",
 		errorCode:  "duplicate_database",
 		query:      fmt.Sprintf("CREATE DATABASE %s", name),
@@ -223,7 +224,7 @@ func createDatabase(log logr.Logger, db *sql.DB, name string) error {
 
 func createSchema(log logr.Logger, db *sql.DB, name string) error {
 	log = log.WithValues("schema", name)
-	return idempotentExec(log, db, idempotentExecReq{
+	return tryExec(log, db, tryExecReq{
 		objectType: "schema",
 		errorCode:  "duplicate_schema",
 		query:      fmt.Sprintf("CREATE SCHEMA %s", name),
@@ -234,7 +235,7 @@ func createRoles(log logr.Logger, db *sql.DB, roles ...string) error {
 	var errs error
 	for _, role := range roles {
 		log := log.WithValues("role", role)
-		err := idempotentExec(log, db, idempotentExecReq{
+		err := tryExec(log, db, tryExecReq{
 			objectType: "service role",
 			errorCode:  "duplicate_object",
 			query:      fmt.Sprintf("CREATE ROLE %s", role),
@@ -249,20 +250,20 @@ func createRoles(log logr.Logger, db *sql.DB, roles ...string) error {
 	return nil
 }
 
-type idempotentExecReq struct {
+type tryExecReq struct {
 	objectType string
 	errorCode  string
 	query      string
 }
 
-func idempotentExec(log logr.Logger, db *sql.DB, args idempotentExecReq) error {
+func tryExec(log logr.Logger, db *sql.DB, args tryExecReq) error {
 	_, err := db.Exec(args.query)
 	if err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code.Name() != args.errorCode {
 			return err
 		}
-		log.Info(fmt.Sprintf("%s already exists", args.objectType), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+		log.Info(fmt.Sprintf("expected err '%s' occured. Ignoring for objectType '%s'", args.errorCode, args.objectType), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
 	} else {
 		log.Info(fmt.Sprintf("%s created", args.objectType))
 	}

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -259,7 +259,6 @@ func idempotentExec(log logr.Logger, db *sql.DB, args idempotentExecReq) error {
 	_, err := db.Exec(args.query)
 	if err != nil {
 		pqError, ok := err.(*pq.Error)
-		log.Info(fmt.Sprintf("MZC Debug: dbQuery: %s, pqErrorCode: %s", args.query, pqError.Code.Name()))
 		if !ok || pqError.Code.Name() != args.errorCode {
 			return err
 		}

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -87,10 +87,10 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials,
 	}
 
 	// TODO: Somewhere around here, do something like
-	// err = execf(db, fmt.Sprintf("GRANT %s TO %s WITH ADMIN OPTION", credentials.Name, managementRole))
-	// if err != nil {
-	// 	return fmt.Errorf("grant %s to management role %s: %w", credentials.Name, managementRole, err)
-	// }
+	err = execf(db, fmt.Sprintf("GRANT %s TO %s WITH ADMIN OPTION", credentials.Name, managementRole))
+	if err != nil {
+		return fmt.Errorf("grant %s to management role %s: %w", credentials.Name, managementRole, err)
+	}
 
 	// Create read and readwrite roles that can be used to grant users access to
 	// the objects in this database.

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -55,7 +55,7 @@ func ParseUsernamePassword(s string) (Credentials, error) {
 // Database ensures that a user with provided password exists on the host and
 // that read and readwrite roles are created with default priviledges on a
 // schema named after the database name.
-func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials) error {
+func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials, managementRole string) error {
 	if host == "" {
 		return fmt.Errorf("host is required")
 	}
@@ -85,6 +85,12 @@ func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials)
 			return fmt.Errorf("grant %s to service user %s: %w", credentials.Name, credentials.User, err)
 		}
 	}
+
+	// TODO: Somewhere around here, do something like
+	// err = execf(db, fmt.Sprintf("GRANT %s TO %s WITH ADMIN OPTION", credentials.Name, managementRole))
+	// if err != nil {
+	// 	return fmt.Errorf("grant %s to management role %s: %w", credentials.Name, managementRole, err)
+	// }
 
 	// Create read and readwrite roles that can be used to grant users access to
 	// the objects in this database.

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -79,7 +79,7 @@ func TestParseUsernamePassword(t *testing.T) {
 func TestDatabase_sunshine(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	managerRoleName := "postgres_role_name"
+	managerRole := "postgres_role_name"
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
@@ -89,7 +89,7 @@ func TestDatabase_sunshine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect to database failed: %v", err)
 	}
-	err = createManagerRole(log, db, managerRoleName)
+	err = createManagerRole(log, db, managerRole)
 	if err != nil {
 		t.Fatalf("create manager role failed: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestDatabase_sunshine(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("EnsurePostgreSQLDatabase failed: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestDatabase_sunshine(t *testing.T) {
 func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	managerRoleName := "postgres_role_name"
+	managerRole := "postgres_role_name"
 	log.Info("TC: Connection as iam_creator")
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
@@ -191,7 +191,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("Create service database failed: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 // referencing the default name of the database instance.
 func TestDatabase_defaultDatabaseName(t *testing.T) {
 	postgresqlHost := test.Integration(t)
-	managerRoleName := "postgres_role_name"
+	managerRole := "postgres_role_name"
 	log := test.SetLogger(t)
 	log.Info("TC: Connecting as iam_creator")
 	db, err := postgres.Connect(log, postgres.ConnectionString{
@@ -242,7 +242,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 	}
 	defer db.Close()
 
-	err = createManagerRole(log, db, managerRoleName)
+	err = createManagerRole(log, db, managerRole)
 	if err != nil {
 		t.Fatalf("create manager role failed: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 		User:     "legacy",
 		Password: "legacy_pass",
 		Shared:   false,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("create legacy database failed: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 		User:     "service",
 		Password: "service_pass",
 		Shared:   true,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("Create service database failed: %v", err)
 	}
@@ -297,9 +297,9 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	sharedDatabaseName := fmt.Sprintf("shared_%d", epoch)
 	newUser := fmt.Sprintf("new_user_%d", epoch)
 	developer := fmt.Sprintf("developer_%d", epoch)
-	managerRoleName := "postgres_role_name"
+	managerRole := "postgres_role_name"
 
-	err = createManagerRole(log, db, managerRoleName)
+	err = createManagerRole(log, db, managerRole)
 	if err != nil {
 		t.Fatalf("create manager role failed: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 		User:     newUser,
 		Password: newUser,
 		Shared:   true,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("create new_user schema on shared database failed: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 func TestDatabase_idempotency(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	managerRoleName := "postgres_role_name"
+	managerRole := "postgres_role_name"
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
@@ -427,7 +427,7 @@ func TestDatabase_idempotency(t *testing.T) {
 		t.Fatalf("connect to database failed: %v", err)
 	}
 
-	err = createManagerRole(log, db, managerRoleName)
+	err = createManagerRole(log, db, managerRole)
 	if err != nil {
 		t.Fatalf("create managerRole: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestDatabase_idempotency(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("EnsurePostgreSQLDatabase failed: %v", err)
 	}
@@ -450,7 +450,7 @@ func TestDatabase_idempotency(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Logf("The error: %#v", err)
 		t.Fatalf("Second EnsurePostgreSQLDatabase failed: %v", err)

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -77,6 +77,7 @@ func TestParseUsernamePassword(t *testing.T) {
 func TestDatabase_sunshine(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
+	managerRoleName := "postgres_role_name"
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
@@ -95,7 +96,7 @@ func TestDatabase_sunshine(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("EnsurePostgreSQLDatabase failed: %v", err)
 	}
@@ -133,6 +134,7 @@ func TestDatabase_sunshine(t *testing.T) {
 func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
+	managerRoleName := "postgres_role_name"
 	log.Info("TC: Connection as iam_creator")
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
@@ -183,7 +185,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("Create service database failed: %v", err)
 	}
@@ -220,6 +222,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 // referencing the default name of the database instance.
 func TestDatabase_defaultDatabaseName(t *testing.T) {
 	postgresqlHost := test.Integration(t)
+	managerRoleName := "postgres_role_name"
 	log := test.SetLogger(t)
 	log.Info("TC: Connecting as iam_creator")
 	db, err := postgres.Connect(log, postgres.ConnectionString{
@@ -240,7 +243,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 		User:     "legacy",
 		Password: "legacy_pass",
 		Shared:   false,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("create legacy database failed: %v", err)
 	}
@@ -252,7 +255,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 		User:     "service",
 		Password: "service_pass",
 		Shared:   true,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("Create service database failed: %v", err)
 	}
@@ -283,6 +286,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	sharedDatabaseName := fmt.Sprintf("shared_%d", epoch)
 	newUser := fmt.Sprintf("new_user_%d", epoch)
 	developer := fmt.Sprintf("developer_%d", epoch)
+	managerRoleName := "postgres_role_name"
 
 	// create the shared database with a role of the same name and owned by the
 	// shared role
@@ -327,7 +331,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 		User:     newUser,
 		Password: newUser,
 		Shared:   true,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("create new_user schema on shared database failed: %v", err)
 	}
@@ -396,6 +400,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 func TestDatabase_idempotency(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
+	managerRoleName := "postgres_role_name"
 	db, err := postgres.Connect(log, postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
@@ -414,7 +419,7 @@ func TestDatabase_idempotency(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("EnsurePostgreSQLDatabase failed: %v", err)
 	}
@@ -424,7 +429,7 @@ func TestDatabase_idempotency(t *testing.T) {
 		Name:     name,
 		User:     name,
 		Password: password,
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Logf("The error: %#v", err)
 		t.Fatalf("Second EnsurePostgreSQLDatabase failed: %v", err)

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -504,11 +504,12 @@ func TestRole_priviliges(t *testing.T) {
 
 func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host, service string) {
 	t.Helper()
+	managerRoleName := "postgres_manager_role"
 	err := postgres.Database(log, database, host, postgres.Credentials{
 		Name:     service,
 		User:     service,
 		Password: "1234",
-	})
+	}, managerRoleName)
 	if err != nil {
 		t.Fatalf("Failed to create database: %v", err)
 	}

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -278,10 +278,12 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 		serviceUser1  = fmt.Sprintf("test_svc_1_%d", now)
 		developerUser = fmt.Sprintf("test_user_%d", now)
 		roleRDSIAM    = fmt.Sprintf("rds_iam_%d", now)
+		// managerRoleName = "postgres_manager_role"
 	)
 	log.Info(fmt.Sprintf("Running test with service users %s and developer %s", serviceUser1, developerUser))
 
 	// create service databases and tables for testing access rights
+	// createRole(t, iamCreatorRootDB, managerRoleName)
 	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser1)
 	createRole(t, iamCreatorRootDB, roleRDSIAM)
 	dbExec(t, iamCreatorRootDB, "GRANT CONNECT ON DATABASE %s TO %s", serviceUser1, roleRDSIAM)
@@ -395,10 +397,12 @@ func TestRole_priviliges(t *testing.T) {
 		serviceUser2  = fmt.Sprintf("test_svc_2_%d", now)
 		developerUser = fmt.Sprintf("test_user_%d", now)
 		roleRDSIAM    = fmt.Sprintf("rds_iam_%d", now)
+		// managerRoleName = "postgres_manager_role"
 	)
 	log.Info(fmt.Sprintf("Running test with service users %s, %s and developer %s", serviceUser1, serviceUser2, developerUser))
 
 	// create service databases and tables for testing access rights
+	// createRole(t, iamCreatorRootDB, managerRoleName)
 	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser1)
 	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser2)
 	createRole(t, iamCreatorRootDB, roleRDSIAM)

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -278,12 +278,10 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 		serviceUser1  = fmt.Sprintf("test_svc_1_%d", now)
 		developerUser = fmt.Sprintf("test_user_%d", now)
 		roleRDSIAM    = fmt.Sprintf("rds_iam_%d", now)
-		// managerRoleName = "postgres_manager_role"
 	)
 	log.Info(fmt.Sprintf("Running test with service users %s and developer %s", serviceUser1, developerUser))
 
 	// create service databases and tables for testing access rights
-	// createRole(t, iamCreatorRootDB, managerRoleName)
 	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser1)
 	createRole(t, iamCreatorRootDB, roleRDSIAM)
 	dbExec(t, iamCreatorRootDB, "GRANT CONNECT ON DATABASE %s TO %s", serviceUser1, roleRDSIAM)
@@ -397,12 +395,10 @@ func TestRole_priviliges(t *testing.T) {
 		serviceUser2  = fmt.Sprintf("test_svc_2_%d", now)
 		developerUser = fmt.Sprintf("test_user_%d", now)
 		roleRDSIAM    = fmt.Sprintf("rds_iam_%d", now)
-		// managerRoleName = "postgres_manager_role"
 	)
 	log.Info(fmt.Sprintf("Running test with service users %s, %s and developer %s", serviceUser1, serviceUser2, developerUser))
 
 	// create service databases and tables for testing access rights
-	// createRole(t, iamCreatorRootDB, managerRoleName)
 	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser1)
 	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser2)
 	createRole(t, iamCreatorRootDB, roleRDSIAM)
@@ -508,12 +504,12 @@ func TestRole_priviliges(t *testing.T) {
 
 func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host, service string) {
 	t.Helper()
-	managerRoleName := "postgres_manager_role"
+	managerRole := "postgres_manager_role"
 	err := postgres.Database(log, database, host, postgres.Credentials{
 		Name:     service,
 		User:     service,
 		Password: "1234",
-	}, managerRoleName)
+	}, managerRole)
 	if err != nil {
 		t.Fatalf("Failed to create database: %v", err)
 	}


### PR DESCRIPTION
Goal: execute `fmt.Sprintf("GRANT %s TO %s WITH ADMIN OPTION", credentials.Name, managerRole)` as it is necessary to have a managerRole after Postgresql 16.
 
To do that, I have renamed the `idempotentExec` to `tryExec` as I am using it with a slightly different use-case than it was being used earlier. The reason I use it, is that we have a test [here](https://github.com/lunarway/postgresql-controller/blob/23da8c6435119592c19f60cb3f6411c52c06805f/controllers/postgresqluser_controller_test.go#L35) which tests that things don't break if we try to reconcile on a bad config. So the above statement has to be run optimistically.

Other than that, it has mostly been setting up tests with the new `managerRole`.