### PR TITLE
fix: logtostderr deprecated

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=0"
         ports:
         - containerPort: 8443


### PR DESCRIPTION
`logtostderr is removed in the k8s upstream and has no effect any more.`