### PR TITLE
Use admin credentials while acting as service user to setup new database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ testbin/*
 *.swo
 *~
 /.vscode
+local.env

--- a/controllers/postgresqldatabase_controller.go
+++ b/controllers/postgresqldatabase_controller.go
@@ -256,26 +256,9 @@ type EnsureParams struct {
 }
 
 func (r *PostgreSQLDatabaseReconciler) EnsurePostgreSQLDatabase(ctx context.Context, log logr.Logger, params *EnsureParams) error {
-	connectionString := postgres.ConnectionString{
-		Host:     params.Host,
-		Database: "postgres", // default database
-		User:     params.Admin.Name,
-		Password: params.Admin.Password,
-		Params:   params.Admin.Params,
-	}
-	db, err := postgres.Connect(log, connectionString)
+	err := postgres.Database(log, params.Host, params.Admin, params.Target, params.ManagerRole)
 	if err != nil {
-		return fmt.Errorf("connect to host %s: %w", connectionString, err)
-	}
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			log.Error(err, "failed to close database connection", "host", params.Host, "database", "postgres", "user", params.Admin.Name)
-		}
-	}()
-	err = postgres.Database(log, db, params.Host, params.Target, params.ManagerRole)
-	if err != nil {
-		return fmt.Errorf("create database %s on host %s: %w", params.Target.Name, connectionString, err)
+		return fmt.Errorf("create database %s on host %s: %w", params.Target.Name, params.Host, err)
 	}
 	return nil
 }

--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -576,7 +576,11 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 	err = createManagerRole(logf.Log, dbConn, managerRole)
 	require.NoErrorf(t, err, "failed to create managerRole for dbConn during seedDatabase")
 
-	err = postgres.Database(logf.Log, dbConn, host, postgres.Credentials{
+	err = postgres.Database(logf.Log, host, postgres.Credentials{
+		Name:     "postgres",
+		Password: "iam_creator",
+		User:     "iam_creator",
+	}, postgres.Credentials{
 		Name:     databaseName,
 		Password: databaseName,
 		User:     userName,

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -101,11 +101,6 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 	if err != nil {
 		return fmt.Errorf("create service user: %w", err)
 	}
-	var (
-		readRole            = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixRead)
-		readWriteRole       = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixWrite)
-		readOwningWriteRole = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixOwningWrite)
-	)
 
 	// if the database is shared we need to grant the existing database role to
 	// the user to allow it to create schemas etc. this is a terrible hack to
@@ -127,6 +122,11 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 
 	// Create read and readwrite roles that can be used to grant users access to
 	// the objects in this database.
+	var (
+		readRole            = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixRead)
+		readWriteRole       = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixWrite)
+		readOwningWriteRole = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixOwningWrite)
+	)
 	err = createRoles(log, serviceConnection, readRole, readWriteRole, readOwningWriteRole)
 	if err != nil {
 		return fmt.Errorf("create service read, readwrite and readowningwrite roles: %w", err)

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -55,147 +55,175 @@ func ParseUsernamePassword(s string) (Credentials, error) {
 // Database ensures that a user with provided password exists on the host and
 // that read and readwrite roles are created with default priviledges on a
 // schema named after the database name.
-func Database(log logr.Logger, db *sql.DB, host string, credentials Credentials, managerRole string) error {
+func Database(log logr.Logger, host string, adminCredentials, serviceCredentials Credentials, managerRole string) error {
 	if host == "" {
 		return fmt.Errorf("host is required")
 	}
 	if managerRole == "" {
 		return fmt.Errorf("managerRole required")
 	}
-	err := credentials.Validate()
+	err := adminCredentials.Validate()
 	if err != nil {
-		return fmt.Errorf("credentials not valid: %w", err)
+		return fmt.Errorf("adminCredentials not valid: %w", err)
+	}
+	err = serviceCredentials.Validate()
+	if err != nil {
+		return fmt.Errorf("serviceCredentials not valid: %w", err)
 	}
 
+	adminConnectionString := ConnectionString{
+		Host:     host,
+		Database: adminCredentials.Name,
+		User:     adminCredentials.User,
+		Password: adminCredentials.Password,
+		Params:   adminCredentials.Params,
+	}
+	adminConnection, err := Connect(log, adminConnectionString)
+	if err != nil {
+		return fmt.Errorf("connect to host %s: %w", adminConnectionString, err)
+	}
+	defer func() {
+		err := adminConnection.Close()
+		if err != nil {
+			log.Error(err, "failed to close database connection", "host", adminConnectionString.Host, "database", "postgres", "user", adminConnectionString.User)
+		}
+	}()
+
 	// Create the service user
-	err = createUser(log, db, credentials.User, credentials.Password)
+	err = createUser(log, adminConnection, serviceCredentials.User, serviceCredentials.Password)
 	if err != nil {
 		return fmt.Errorf("create service user: %w", err)
 	}
 	var (
-		readRole            = fmt.Sprintf("%s_%s", credentials.User, roleSuffixRead)
-		readWriteRole       = fmt.Sprintf("%s_%s", credentials.User, roleSuffixWrite)
-		readOwningWriteRole = fmt.Sprintf("%s_%s", credentials.User, roleSuffixOwningWrite)
+		readRole            = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixRead)
+		readWriteRole       = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixWrite)
+		readOwningWriteRole = fmt.Sprintf("%s_%s", serviceCredentials.User, roleSuffixOwningWrite)
 	)
 
 	// if the database is shared we need to grant the existing database role to
 	// the user to allow it to create schemas etc. this is a terrible hack to
 	// support services using a shared database with mixed owners of the resources.
-	if credentials.Shared {
+	if serviceCredentials.Shared {
 		// ensures access to existing schemas and tables
-		err = execf(db, fmt.Sprintf("GRANT %s TO %s", credentials.Name, credentials.User))
+		err = execf(adminConnection, fmt.Sprintf("GRANT %s TO %s", serviceCredentials.Name, serviceCredentials.User))
 		if err != nil {
-			return fmt.Errorf("grant %s to service user %s: %w", credentials.Name, credentials.User, err)
+			return fmt.Errorf("grant %s to service user %s: %w", serviceCredentials.Name, serviceCredentials.User, err)
 		}
 	}
 
 	// Grant the service user role to the managerRole WITH ADMIN OPTION
 	// This allows the managerRole to act on behalf of the service user
-	err = grantAdminOption(log, db, credentials.Name, managerRole)
+	err = grantAdminOption(log, adminConnection, serviceCredentials.Name, managerRole)
 	if err != nil {
-		return fmt.Errorf("grant %s to management role %s: %w", credentials.Name, managerRole, err)
+		return fmt.Errorf("grant %s to management role %s: %w", serviceCredentials.Name, managerRole, err)
 	}
 
 	// Create read and readwrite roles that can be used to grant users access to
 	// the objects in this database.
-	err = createRoles(log, db, readRole, readWriteRole, readOwningWriteRole)
+	err = createRoles(log, adminConnection, readRole, readWriteRole, readOwningWriteRole)
 	if err != nil {
 		return fmt.Errorf("create service read, readwrite and readowningwrite roles: %w", err)
 	}
 
 	// Create the database
-	err = createDatabase(log, db, credentials.Name)
+	err = createDatabase(log, adminConnection, serviceCredentials.Name)
 	if err != nil {
-		return fmt.Errorf("create service database '%s': %w", credentials.Name, err)
+		return fmt.Errorf("create service database '%s': %w", serviceCredentials.Name, err)
 	}
+
+	// Alter ownership of the database to the database user. The current user
+	// needs to belong to the new role before owner ship can be changed.
+	err = execf(adminConnection, "GRANT %s TO CURRENT_USER", serviceCredentials.User)
+	if err != nil {
+		return fmt.Errorf("grant new role '%s' to creator role: %w", serviceCredentials.User, err)
+	}
+	defer func() {
+		err = execf(adminConnection, "REVOKE %s FROM CURRENT_USER", serviceCredentials.User)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("revoke new role '%s' to creator role", serviceCredentials.User))
+		}
+	}()
 
 	// if the database is shared we cannot grant the service user ownership of the
 	// database as that would break the actual owners rights.
-	if !credentials.Shared {
-		// Alter ownership of the database to the database user. The current user
-		// needs to belong to the new role before owner ship can be changed.
-		err = execf(db, "GRANT %s TO CURRENT_USER", credentials.User)
+	if !serviceCredentials.Shared {
+
+		err = execf(adminConnection, "ALTER DATABASE %s OWNER TO %s", serviceCredentials.Name, serviceCredentials.User)
 		if err != nil {
-			return fmt.Errorf("grant new role '%s' to creator role: %w", credentials.User, err)
-		}
-		err = execf(db, "ALTER DATABASE %s OWNER TO %s", credentials.Name, credentials.User)
-		if err != nil {
-			return fmt.Errorf("alter owner of database %s to %s: %w", credentials.Name, credentials.User, err)
-		}
-		err = execf(db, "REVOKE %s FROM CURRENT_USER", credentials.User)
-		if err != nil {
-			return fmt.Errorf("revoke new role '%s' to creator role: %w", credentials.User, err)
+			return fmt.Errorf("alter owner of database %s to %s: %w", serviceCredentials.Name, serviceCredentials.User, err)
 		}
 	}
 
-	// Connect with the newly created role to create the schema with that role.
-	// This ensures that the object is in fact owned by the service and not the
-	// creator role.
-	serviceConnection, err := Connect(log, ConnectionString{
-		Host:     host,
-		Database: credentials.Name,
-		User:     credentials.User,
-		Password: credentials.Password,
-	})
+	// Grant the service role (which is owner) to the readowningwrite role
+	err = execf(adminConnection, "GRANT %s TO %s", serviceCredentials.User, readOwningWriteRole)
 	if err != nil {
-		return fmt.Errorf("connect with new user %s: %w", credentials.Name, err)
+		return fmt.Errorf("grant owner %s to readowningwrite for role %s: %w", serviceCredentials.User, readOwningWriteRole, err)
+	}
+
+	// Execute the rest of the queries as the service user on the service database
+	serviceConnectionString := ConnectionString{
+		Host:     host,
+		Database: serviceCredentials.Name,
+		User:     adminCredentials.User,
+		Password: adminCredentials.Password,
+		Params:   adminCredentials.Params,
+	}
+	serviceConnection, err := Connect(log, serviceConnectionString)
+	if err != nil {
+		return fmt.Errorf("connect to host %s: %w", serviceConnectionString, err)
 	}
 	defer func() {
 		err := serviceConnection.Close()
 		if err != nil {
-			log.Error(err, "failed to close service database connection", "host", host, "database", credentials.Name, "user", credentials.Name)
+			log.Error(err, "failed to close database connection", "host", serviceConnectionString.Host, "database", "postgres", "user", serviceConnectionString.User)
 		}
 	}()
 
 	// Create schema in the database
-	err = createSchema(log, serviceConnection, credentials.User)
+	err = createSchemaAs(log, serviceConnection, serviceCredentials.User, serviceCredentials.User)
 	if err != nil {
-		return fmt.Errorf("create schema '%s' as service user '%[1]s': %w", credentials.User, err)
+		return fmt.Errorf("create schema '%s' as service user '%[1]s': %w", serviceCredentials.User, err)
 	}
 
 	// set default read and write priviledges on the read and readwrite roles as
 	// to ensure the roles' priviledges apply to all objects created later on.
-	err = setReadPriviledges(serviceConnection, credentials.User, readRole)
+	err = setReadPriviledgesAs(serviceConnection, serviceCredentials.User, readRole, serviceCredentials.User)
 	if err != nil {
-		return fmt.Errorf("set default read priviledges for role %s: %w", readRole, err)
+		return fmt.Errorf("set default read priviledges for role %s: %w, as %s", readRole, err, serviceCredentials.User)
 	}
-	err = setReadWritePriviledges(serviceConnection, credentials.User, readWriteRole)
+	err = setReadWritePriviledgesAs(serviceConnection, serviceCredentials.User, readWriteRole, serviceCredentials.User)
 	if err != nil {
-		return fmt.Errorf("set default readwrite priviledges for role %s: %w", readWriteRole, err)
+		return fmt.Errorf("set default readwrite priviledges for role %s: %w, as %s", readWriteRole, err, serviceCredentials.User)
 	}
 
 	// an owning write request makes it possible to do everything a read and
 	// readwrite role can along with being granted the owner role to allow DROP
 	// and ALTER as well
-	err = setReadWritePriviledges(serviceConnection, credentials.User, readOwningWriteRole)
+	err = setReadWritePriviledgesAs(serviceConnection, serviceCredentials.User, readOwningWriteRole, serviceCredentials.User)
 	if err != nil {
-		return fmt.Errorf("set default readowningwrite priviledges for role %s: %w", readOwningWriteRole, err)
-	}
-	err = execf(db, "GRANT %s TO %s", credentials.User, readOwningWriteRole)
-	if err != nil {
-		return fmt.Errorf("grant owner %s to readowningwrite for role %s: %w", credentials.User, readOwningWriteRole, err)
+		return fmt.Errorf("set default readowningwrite priviledges for role %s: %w, as %s", readOwningWriteRole, err, serviceCredentials.User)
 	}
 
 	// This revokation ensures that the user cannot create any objects in the
 	// PUBLIC role that is assigned to all roles by default.
-	log.Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", credentials.Name))
-	err = execf(serviceConnection, `
+	log.Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", serviceCredentials.Name))
+	err = execAsf(serviceConnection, serviceCredentials.User, `
 		REVOKE ALL ON DATABASE %s from PUBLIC;
 		REVOKE ALL ON SCHEMA public from PUBLIC;
-		REVOKE ALL ON ALL TABLES IN SCHEMA public from PUBLIC;`, credentials.Name)
+		REVOKE ALL ON ALL TABLES IN SCHEMA public from PUBLIC;`, serviceCredentials.Name)
 	if err != nil {
-		return fmt.Errorf("revoke all for role PUBLIC on database '%s': %w", credentials.Name, err)
+		return fmt.Errorf("revoke all for role PUBLIC on database '%s': %w, as %s", serviceCredentials.Name, err, serviceCredentials.User)
 	}
 	// Grant CONNECT privileges to PUBLIC again to ensure new roles are allowed to connect.
 	log.Info("Grant CONNECT to PUBLIC")
-	err = execf(serviceConnection, "GRANT CONNECT ON DATABASE %s TO PUBLIC", credentials.Name)
+	err = execAsf(serviceConnection, serviceCredentials.User, "GRANT CONNECT ON DATABASE %s TO PUBLIC", serviceCredentials.Name)
 	if err != nil {
-		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w", credentials.Name, err)
+		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w as %s", serviceCredentials.Name, err, serviceCredentials.User)
 	}
-	log.Info(fmt.Sprintf("Grant usage on schema '%s' to PUBLIC", credentials.User))
-	err = execf(serviceConnection, "GRANT USAGE ON SCHEMA %s TO PUBLIC", credentials.User)
+	log.Info(fmt.Sprintf("Grant usage on schema '%s' to PUBLIC", serviceCredentials.User))
+	err = execAsf(serviceConnection, serviceCredentials.User, "GRANT USAGE ON SCHEMA %s TO PUBLIC", serviceCredentials.User)
 	if err != nil {
-		return fmt.Errorf("grant usage on schema '%s' to PUBLIC: %w", credentials.User, err)
+		return fmt.Errorf("grant usage on schema '%s' to PUBLIC: %w as %s", serviceCredentials.User, err, serviceCredentials.User)
 	}
 	return nil
 }
@@ -218,12 +246,12 @@ func createDatabase(log logr.Logger, db *sql.DB, name string) error {
 	})
 }
 
-func createSchema(log logr.Logger, db *sql.DB, name string) error {
-	log = log.WithValues("schema", name)
+func createSchemaAs(log logr.Logger, db *sql.DB, schema, actor string) error {
+	log = log.WithValues("schema", schema)
 	return tryExec(log, db, tryExecReq{
 		objectType: "schema",
 		errorCode:  "duplicate_schema",
-		query:      fmt.Sprintf("CREATE SCHEMA %s", name),
+		query:      prependSetRole(fmt.Sprintf("CREATE SCHEMA %s", schema), actor),
 	})
 }
 
@@ -274,32 +302,32 @@ func tryExec(log logr.Logger, db *sql.DB, args tryExecReq) error {
 	return nil
 }
 
-func setReadPriviledges(db *sql.DB, schema string, role string) error {
-	return setDefaultPriviledges(db, schema, role, "SELECT")
+func setReadPriviledgesAs(db *sql.DB, schema, role, actor string) error {
+	return setDefaultPriviledgesAs(db, schema, role, "SELECT", actor)
 }
 
-func setReadWritePriviledges(db *sql.DB, schema string, role string) error {
-	return setDefaultPriviledges(db, schema, role, "SELECT, INSERT, UPDATE, DELETE")
+func setReadWritePriviledgesAs(db *sql.DB, schema, role, actor string) error {
+	return setDefaultPriviledgesAs(db, schema, role, "SELECT, INSERT, UPDATE, DELETE", actor)
 }
 
-func setDefaultPriviledges(db *sql.DB, schema, role, priviledges string) error {
+func setDefaultPriviledgesAs(db *sql.DB, schema, role, priviledges, actor string) error {
 	// ensures access to future schemas and tables
-	err := execf(db, "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT %s ON TABLES TO %s;", schema, priviledges, role)
+	err := execAsf(db, actor, "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT %s ON TABLES TO %s;", schema, priviledges, role)
 	if err != nil {
-		return fmt.Errorf("alter default privileges of schema: %w", err)
+		return fmt.Errorf("alter default privileges of schema: %w, as %s", err, actor)
 	}
-	err = execf(db, "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT %s ON TABLES TO %s;", priviledges, role)
+	err = execAsf(db, actor, "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT %s ON TABLES TO %s;", priviledges, role)
 	if err != nil {
-		return fmt.Errorf("alter default privileges of public schema: %w", err)
+		return fmt.Errorf("alter default privileges of public schema: %w, as %s", err, actor)
 	}
 	// ensures access to existing schemas and tables
-	err = execf(db, fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO %s", schema, role))
+	err = execAsf(db, actor, fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO %s", schema, role))
 	if err != nil {
-		return fmt.Errorf("grant %s privileges on existing schema: %w", priviledges, err)
+		return fmt.Errorf("grant %s privileges on existing schema: %w, as %s", priviledges, err, actor)
 	}
-	err = execf(db, fmt.Sprintf("GRANT %s ON ALL TABLES IN SCHEMA %s TO %s", priviledges, schema, role))
+	err = execAsf(db, actor, fmt.Sprintf("GRANT %s ON ALL TABLES IN SCHEMA %s TO %s", priviledges, schema, role))
 	if err != nil {
-		return fmt.Errorf("grant %s privileges on existing tables: %w", priviledges, err)
+		return fmt.Errorf("grant %s privileges on existing tables: %w, as %s", priviledges, err, actor)
 	}
 	return nil
 }
@@ -311,4 +339,19 @@ func execf(db *sql.DB, query string, args ...interface{}) error {
 		return err
 	}
 	return nil
+}
+
+// execf executes a formatted query on db as given role.
+func execAsf(db *sql.DB, role string, query string, args ...interface{}) error {
+	err := execf(db, prependSetRole(query, role), args...)
+	if err != nil {
+		return fmt.Errorf("unable to execute query '%s', with args %v. %w", prependSetRole(query, role), args, err)
+	}
+	return nil
+}
+
+func prependSetRole(query, role string) string {
+	return fmt.Sprintf(`
+		SET ROLE %s;
+		%s`, role, query)
 }

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -98,11 +98,16 @@ func TestDatabase_sunshine(t *testing.T) {
 	name := fmt.Sprintf("test_%d", time.Now().UnixNano())
 	password := "test"
 
-	err = postgres.Database(logf.Log, db, postgresqlHost, postgres.Credentials{
-		Name:     name,
-		User:     name,
-		Password: password,
-	}, managerRole)
+	err = postgres.Database(logf.Log, postgresqlHost,
+		postgres.Credentials{
+			Name:     "postgres",
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     name,
+			User:     name,
+			Password: password,
+		}, managerRole)
 	if err != nil {
 		t.Fatalf("EnsurePostgreSQLDatabase failed: %v", err)
 	}
@@ -187,11 +192,16 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	`, name))
 
 	log.Info("TC: Run controller database creation")
-	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
-		Name:     name,
-		User:     name,
-		Password: password,
-	}, managerRole)
+	err = postgres.Database(log, postgresqlHost,
+		postgres.Credentials{
+			Name:     "postgres",
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     name,
+			User:     name,
+			Password: password,
+		}, managerRole)
 	if err != nil {
 		t.Fatalf("Create service database failed: %v", err)
 	}
@@ -249,24 +259,34 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 
 	// setup a database that will be shared
 	log.Info("TC: Create a legacy database that will be shared with other services")
-	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
-		Name:     "legacy",
-		User:     "legacy",
-		Password: "legacy_pass",
-		Shared:   false,
-	}, managerRole)
+	err = postgres.Database(log, postgresqlHost,
+		postgres.Credentials{
+			Name:     "postgres",
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     "legacy",
+			User:     "legacy",
+			Password: "legacy_pass",
+			Shared:   false,
+		}, managerRole)
 	if err != nil {
 		t.Fatalf("create legacy database failed: %v", err)
 	}
 
 	// setup a new schema on the shared database
 	log.Info("TC: Request new database using default postgres database (postgres)")
-	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
-		Name:     "legacy",
-		User:     "service",
-		Password: "service_pass",
-		Shared:   true,
-	}, managerRole)
+	err = postgres.Database(log, postgresqlHost,
+		postgres.Credentials{
+			Name:     "postgres",
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     "legacy",
+			User:     "service",
+			Password: "service_pass",
+			Shared:   true,
+		}, managerRole)
 	if err != nil {
 		t.Fatalf("Create service database failed: %v", err)
 	}
@@ -342,12 +362,17 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	// shared database with a new user where the schema exists created by the
 	// shared user
 	log.Info("TC: Create new_user database on shared database")
-	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
-		Name:     sharedDatabaseName,
-		User:     newUser,
-		Password: newUser,
-		Shared:   true,
-	}, managerRole)
+	err = postgres.Database(log, postgresqlHost,
+		postgres.Credentials{
+			Name:     "postgres",
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     sharedDatabaseName,
+			User:     newUser,
+			Password: newUser,
+			Shared:   true,
+		}, managerRole)
 	if err != nil {
 		t.Fatalf("create new_user schema on shared database failed: %v", err)
 	}
@@ -436,7 +461,11 @@ func TestDatabase_idempotency(t *testing.T) {
 	name := fmt.Sprintf("test_%d", time.Now().UnixNano())
 	password := "test"
 
-	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
+	err = postgres.Database(log, postgresqlHost, postgres.Credentials{
+		Name:     "postgres",
+		User:     "iam_creator",
+		Password: "iam_creator",
+	}, postgres.Credentials{
 		Name:     name,
 		User:     name,
 		Password: password,
@@ -446,7 +475,11 @@ func TestDatabase_idempotency(t *testing.T) {
 	}
 
 	// Invoke again with same name
-	err = postgres.Database(log, db, postgresqlHost, postgres.Credentials{
+	err = postgres.Database(log, postgresqlHost, postgres.Credentials{
+		Name:     "postgres",
+		User:     "iam_creator",
+		Password: "iam_creator",
+	}, postgres.Credentials{
 		Name:     name,
 		User:     name,
 		Password: password,

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -282,7 +282,7 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 	log.Info(fmt.Sprintf("Running test with service users %s and developer %s", serviceUser1, developerUser))
 
 	// create service databases and tables for testing access rights
-	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser1)
+	createServiceDatabase(t, log, postgresqlHost, serviceUser1)
 	createRole(t, iamCreatorRootDB, roleRDSIAM)
 	dbExec(t, iamCreatorRootDB, "GRANT CONNECT ON DATABASE %s TO %s", serviceUser1, roleRDSIAM)
 
@@ -399,8 +399,8 @@ func TestRole_priviliges(t *testing.T) {
 	log.Info(fmt.Sprintf("Running test with service users %s, %s and developer %s", serviceUser1, serviceUser2, developerUser))
 
 	// create service databases and tables for testing access rights
-	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser1)
-	createServiceDatabase(t, log, iamCreatorRootDB, postgresqlHost, serviceUser2)
+	createServiceDatabase(t, log, postgresqlHost, serviceUser1)
+	createServiceDatabase(t, log, postgresqlHost, serviceUser2)
 	createRole(t, iamCreatorRootDB, roleRDSIAM)
 	dbExec(t, iamCreatorRootDB, "GRANT CONNECT ON DATABASE %s TO %s", serviceUser1, roleRDSIAM)
 	dbExec(t, iamCreatorRootDB, "GRANT CONNECT ON DATABASE %s TO %s", serviceUser2, roleRDSIAM)
@@ -502,14 +502,19 @@ func TestRole_priviliges(t *testing.T) {
 	}
 }
 
-func createServiceDatabase(t *testing.T, log logr.Logger, database *sql.DB, host, service string) {
+func createServiceDatabase(t *testing.T, log logr.Logger, host, service string) {
 	t.Helper()
 	managerRole := "postgres_manager_role"
-	err := postgres.Database(log, database, host, postgres.Credentials{
-		Name:     service,
-		User:     service,
-		Password: "1234",
-	}, managerRole)
+	err := postgres.Database(log, host,
+		postgres.Credentials{
+			Name:     "postgres",
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     service,
+			User:     service,
+			Password: "1234",
+		}, managerRole)
 	if err != nil {
 		t.Fatalf("Failed to create database: %v", err)
 	}


### PR DESCRIPTION
As discussed this is step 1 of a two step operation which is:
1. Refactor to allow the controller to operate on a service db without being logged in as the service user
2. Do not create a login for the service user/role unless needed