### PR TITLE
Align HostCredentials and ServiceCredentials on User/Name field

### DIFF
--- a/config.go
+++ b/config.go
@@ -130,7 +130,7 @@ func (h *hostCredentials) String() string {
 	}
 	records := make([]string, 0, len(*h.value)>>1)
 	for k, v := range *h.value {
-		pair := k + "=" + v.Name
+		pair := k + "=" + v.User
 		if v.Password != "" {
 			pair += ":********"
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -39,7 +39,7 @@ func TestHostCredentials_Set(t *testing.T) {
 			err:   nil,
 			output: map[string]postgres.Credentials{
 				"host:5432": {
-					Name:     "user",
+					User:     "user",
 					Password: "pass",
 				},
 			},
@@ -50,11 +50,11 @@ func TestHostCredentials_Set(t *testing.T) {
 			err:   nil,
 			output: map[string]postgres.Credentials{
 				"host1:5432": {
-					Name:     "user1",
+					User:     "user1",
 					Password: "pass1",
 				},
 				"host2:5432": {
-					Name:     "user2",
+					User:     "user2",
 					Password: "pass2",
 				},
 			},
@@ -71,7 +71,7 @@ func TestHostCredentials_Set(t *testing.T) {
 			err:   nil,
 			output: map[string]postgres.Credentials{
 				"host1:5432": {
-					Name:     "user1",
+					User:     "user1",
 					Password: "pass1",
 					Params:   "sslmode=enabled",
 				},
@@ -117,7 +117,7 @@ func TestHostCredentials_String(t *testing.T) {
 			name: "single host",
 			value: map[string]postgres.Credentials{
 				"host:5432": {
-					Name:     "user",
+					User:     "user",
 					Password: "pass",
 				},
 			},
@@ -127,11 +127,11 @@ func TestHostCredentials_String(t *testing.T) {
 			name: "multiple hosts",
 			value: map[string]postgres.Credentials{
 				"host1:5432": {
-					Name:     "user1",
+					User:     "user1",
 					Password: "pass1",
 				},
 				"host2:5432": {
-					Name:     "user2",
+					User:     "user2",
 					Password: "pass2",
 				},
 			},

--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -138,7 +138,7 @@ func TestReconcile_badConfigmapReference(t *testing.T) {
 			Now: time.Now,
 			HostCredentials: map[string]postgres.Credentials{
 				host: {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "iam_creator",
 				},
 			},
@@ -255,7 +255,7 @@ func TestReconcile_rolePrefix(t *testing.T) {
 			Now: time.Now,
 			HostCredentials: map[string]postgres.Credentials{
 				host: {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "iam_creator",
 				},
 			},
@@ -374,7 +374,7 @@ func TestReconcile_dotInName(t *testing.T) {
 			Now: time.Now,
 			HostCredentials: map[string]postgres.Credentials{
 				host: {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "iam_creator",
 				},
 			},
@@ -522,7 +522,7 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 			Now: time.Now,
 			HostCredentials: map[string]postgres.Credentials{
 				host: {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "iam_creator",
 				},
 			},
@@ -577,7 +577,7 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 	require.NoErrorf(t, err, "failed to create managerRole for dbConn during seedDatabase")
 
 	err = postgres.Database(logf.Log, host, postgres.Credentials{
-		Name:     "iam_creator",
+		User:     "iam_creator",
 		Password: "iam_creator",
 	}, postgres.Credentials{
 		Name:     databaseName,

--- a/controllers/postgresqluser_controller_test.go
+++ b/controllers/postgresqluser_controller_test.go
@@ -577,9 +577,8 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 	require.NoErrorf(t, err, "failed to create managerRole for dbConn during seedDatabase")
 
 	err = postgres.Database(logf.Log, host, postgres.Credentials{
-		Name:     "postgres",
+		Name:     "iam_creator",
 		Password: "iam_creator",
-		User:     "iam_creator",
 	}, postgres.Credentials{
 		Name:     databaseName,
 		Password: databaseName,

--- a/pkg/grants/grants_test.go
+++ b/pkg/grants/grants_test.go
@@ -779,7 +779,7 @@ func TestGranter_connectToHosts(t *testing.T) {
 			name: "single host with credentials",
 			credentials: map[string]postgres.Credentials{
 				"localhost:5432": {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "iam_creator",
 				},
 			},
@@ -800,11 +800,11 @@ func TestGranter_connectToHosts(t *testing.T) {
 			name: "multiple hosts without upstream",
 			credentials: map[string]postgres.Credentials{
 				"localhost:5432": {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "iam_creator",
 				},
 				"unknown": {
-					Name:     "iam_creator",
+					User:     "iam_creator",
 					Password: "12345678",
 				},
 			},

--- a/pkg/grants/sync.go
+++ b/pkg/grants/sync.go
@@ -70,7 +70,7 @@ func (g *Granter) connectToHosts(log logr.Logger, accesses HostAccess) (map[stri
 		connectionString := postgres.ConnectionString{
 			Host:     host,
 			Database: database,
-			User:     credentials.Name,
+			User:     credentials.User,
 			Password: credentials.Password,
 		}
 		db, err := postgres.Connect(log, connectionString)

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -62,11 +62,7 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 	if managerRole == "" {
 		return fmt.Errorf("managerRole required")
 	}
-	err := adminCredentials.Validate()
-	if err != nil {
-		return fmt.Errorf("adminCredentials not valid: %w", err)
-	}
-	err = serviceCredentials.Validate()
+	err := serviceCredentials.Validate()
 	if err != nil {
 		return fmt.Errorf("serviceCredentials not valid: %w", err)
 	}
@@ -81,7 +77,7 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 	serviceConnectionString := ConnectionString{
 		Host:     host,
 		Database: serviceCredentials.Name,
-		User:     adminCredentials.User,
+		User:     adminCredentials.Name,
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}
@@ -204,8 +200,8 @@ func createDatabase(log logr.Logger, host string, adminCredentials Credentials, 
 
 	connectionString := ConnectionString{
 		Host:     host,
-		Database: adminCredentials.Name,
-		User:     adminCredentials.User,
+		Database: "postgres",
+		User:     adminCredentials.Name,
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -44,7 +44,7 @@ func ParseUsernamePassword(s string) (Credentials, error) {
 		return Credentials{}, fmt.Errorf("username empty")
 	}
 	c := Credentials{
-		Name: pair[0],
+		User: pair[0],
 	}
 	if len(pair) == 2 {
 		c.Password = pair[1]
@@ -77,7 +77,7 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 	serviceConnectionString := ConnectionString{
 		Host:     host,
 		Database: serviceCredentials.Name,
-		User:     adminCredentials.Name,
+		User:     adminCredentials.User,
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}
@@ -201,7 +201,7 @@ func createDatabase(log logr.Logger, host string, adminCredentials Credentials, 
 	connectionString := ConnectionString{
 		Host:     host,
 		Database: "postgres",
-		User:     adminCredentials.Name,
+		User:     adminCredentials.User,
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -33,7 +33,7 @@ func TestParseUsernamePassword(t *testing.T) {
 			name:  "complete",
 			input: "user:password",
 			output: postgres.Credentials{
-				Name:     "user",
+				User:     "user",
 				Password: "password",
 			},
 			err: nil,
@@ -42,7 +42,7 @@ func TestParseUsernamePassword(t *testing.T) {
 			name:  "no password",
 			input: "user",
 			output: postgres.Credentials{
-				Name:     "user",
+				User:     "user",
 				Password: "",
 			},
 			err: nil,
@@ -51,7 +51,7 @@ func TestParseUsernamePassword(t *testing.T) {
 			name:  "empty password",
 			input: "user:",
 			output: postgres.Credentials{
-				Name:     "user",
+				User:     "user",
 				Password: "",
 			},
 			err: nil,
@@ -100,7 +100,7 @@ func TestDatabase_sunshine(t *testing.T) {
 
 	err = postgres.Database(logf.Log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "iam_creator",
+			User:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     name,
@@ -193,7 +193,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	log.Info("TC: Run controller database creation")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "iam_creator",
+			User:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     name,
@@ -259,7 +259,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 	log.Info("TC: Create a legacy database that will be shared with other services")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "iam_creator",
+			User:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     "legacy",
@@ -275,7 +275,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 	log.Info("TC: Request new database using default postgres database (postgres)")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "iam_creator",
+			User:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     "legacy",
@@ -360,7 +360,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	log.Info("TC: Create new_user database on shared database")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "iam_creator",
+			User:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     sharedDatabaseName,
@@ -457,7 +457,7 @@ func TestDatabase_idempotency(t *testing.T) {
 	password := "test"
 
 	err = postgres.Database(log, postgresqlHost, postgres.Credentials{
-		Name:     "iam_creator",
+		User:     "iam_creator",
 		Password: "iam_creator",
 	}, postgres.Credentials{
 		Name:     name,
@@ -470,7 +470,7 @@ func TestDatabase_idempotency(t *testing.T) {
 
 	// Invoke again with same name
 	err = postgres.Database(log, postgresqlHost, postgres.Credentials{
-		Name:     "iam_creator",
+		User:     "iam_creator",
 		Password: "iam_creator",
 	}, postgres.Credentials{
 		Name:     name,

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -100,8 +100,7 @@ func TestDatabase_sunshine(t *testing.T) {
 
 	err = postgres.Database(logf.Log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "postgres",
-			User:     "iam_creator",
+			Name:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     name,
@@ -194,8 +193,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	log.Info("TC: Run controller database creation")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "postgres",
-			User:     "iam_creator",
+			Name:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     name,
@@ -261,8 +259,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 	log.Info("TC: Create a legacy database that will be shared with other services")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "postgres",
-			User:     "iam_creator",
+			Name:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     "legacy",
@@ -278,8 +275,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 	log.Info("TC: Request new database using default postgres database (postgres)")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "postgres",
-			User:     "iam_creator",
+			Name:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     "legacy",
@@ -364,8 +360,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	log.Info("TC: Create new_user database on shared database")
 	err = postgres.Database(log, postgresqlHost,
 		postgres.Credentials{
-			Name:     "postgres",
-			User:     "iam_creator",
+			Name:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     sharedDatabaseName,
@@ -462,8 +457,7 @@ func TestDatabase_idempotency(t *testing.T) {
 	password := "test"
 
 	err = postgres.Database(log, postgresqlHost, postgres.Credentials{
-		Name:     "postgres",
-		User:     "iam_creator",
+		Name:     "iam_creator",
 		Password: "iam_creator",
 	}, postgres.Credentials{
 		Name:     name,
@@ -476,8 +470,7 @@ func TestDatabase_idempotency(t *testing.T) {
 
 	// Invoke again with same name
 	err = postgres.Database(log, postgresqlHost, postgres.Credentials{
-		Name:     "postgres",
-		User:     "iam_creator",
+		Name:     "iam_creator",
 		Password: "iam_creator",
 	}, postgres.Credentials{
 		Name:     name,

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -507,8 +507,7 @@ func createServiceDatabase(t *testing.T, log logr.Logger, host, service string) 
 	managerRole := "postgres_manager_role"
 	err := postgres.Database(log, host,
 		postgres.Credentials{
-			Name:     "postgres",
-			User:     "iam_creator",
+			Name:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     service,

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -507,7 +507,7 @@ func createServiceDatabase(t *testing.T, log logr.Logger, host, service string) 
 	managerRole := "postgres_manager_role"
 	err := postgres.Database(log, host,
 		postgres.Credentials{
-			Name:     "iam_creator",
+			User:     "iam_creator",
 			Password: "iam_creator",
 		}, postgres.Credentials{
 			Name:     service,


### PR DESCRIPTION
When parsing HostCredentials db username was put in Credentials.Name but in ServiceCredentials the db user/role was put in Credentials.User while Credentials.Name holds the database name. This aligns the two uses of the Credentials struct.

- Do not validate admin credentials and hardcode database for admin connection
- Align HostCredentials and ServiceCredentials on User/Name field
