### PR TITLE
Delete password not just login from user when password removed from CR

### DIFF
--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -195,9 +195,9 @@ func createServiceRole(log logr.Logger, db *sql.DB, user, password string) error
 	}
 
 	if password != "" {
-		err = execf(db, "ALTER ROLE %s LOGIN PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'", user, password)
+		err = execf(db, "ALTER ROLE %s LOGIN PASSWORD '%s' VALID UNTIL 'infinity'", user, password)
 	} else {
-		err = execf(db, "ALTER ROLE %s NOLOGIN NOCREATEROLE", user)
+		err = execf(db, "ALTER ROLE %s NOLOGIN PASSWORD NULL", user)
 	}
 	return err
 }


### PR DESCRIPTION
Previous PR removed the role's login if there was no password in the CR but did not actually remove the password itself. This is now removed properly.