### PR TITLE
experiment: add end to end tests

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 


### PR DESCRIPTION
Currently we test our loop by calling Reconcile ourselves with resource, this actually adds resources to the testenv kubernetes, and the operator should reconcile the resources itself

The test framework is a little bit weird tho. We may consider just doing the same thing in our own tests, or something
