### PR TITLE
Reduce logging

### DIFF
--- a/internal/controller/postgresqldatabase_controller.go
+++ b/internal/controller/postgresqldatabase_controller.go
@@ -74,7 +74,7 @@ func (r *PostgreSQLDatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, reqLogger logr.Logger, request reconcile.Request) (status, error) {
-	reqLogger.Info("Reconciling PostgreSQLDatabase")
+	reqLogger.V(1).Info("Reconciling PostgreSQLDatabase")
 	// Fetch the PostgreSQLDatabase instance
 	database := &postgresqlv1alpha1.PostgreSQLDatabase{}
 	err := r.Client.Get(ctx, request.NamespacedName, database)
@@ -92,7 +92,7 @@ func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, reqLogger 
 		"database", database.Spec.Name,
 		"isShared", database.Spec.IsShared,
 	)
-	reqLogger.Info("Updating PostgreSQLDatabase resource")
+	reqLogger.V(1).Info("Updating PostgreSQLDatabase resource")
 
 	status := status{
 		log:      reqLogger,

--- a/internal/controller/postgresqlhostcredentials_controller.go
+++ b/internal/controller/postgresqlhostcredentials_controller.go
@@ -51,7 +51,7 @@ func (r *PostgreSQLHostCredentialsReconciler) Reconcile(ctx context.Context, req
 		reqLogger.Error(err, "Failed to pick a request ID. Continuing without")
 	}
 	reqLogger = reqLogger.WithValues("requestId", requestID.String())
-	reqLogger.Info("Reconciling PostgreSQLHostCredentials")
+	reqLogger.V(1).Info("Reconciling PostgreSQLHostCredentials")
 
 	result, err := r.reconcile(ctx, reqLogger, req)
 	if err != nil {

--- a/internal/controller/postgresqluser_controller.go
+++ b/internal/controller/postgresqluser_controller.go
@@ -76,7 +76,7 @@ func (r *PostgreSQLUserReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		reqLogger.Error(err, "Failed to pick a request ID. Continuing without")
 	}
 	reqLogger = reqLogger.WithValues("requestId", requestID.String())
-	reqLogger.Info("Reconciling PostgreSQLUSer")
+	reqLogger.V(1).Info("Reconciling PostgreSQLUSer")
 
 	result, err := r.reconcile(ctx, reqLogger, req)
 	if err != nil {
@@ -120,7 +120,7 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr
 
 	// User instance created or updated
 	reqLogger = reqLogger.WithValues("user", user.Spec.Name, "rolePrefix", r.RolePrefix)
-	reqLogger.Info("Reconciling found PostgreSQLUser resource", "user", user.Spec.Name)
+	reqLogger.V(1).Info("Reconciling found PostgreSQLUser resource", "user", user.Spec.Name)
 
 	awsConfig := &aws.Config{
 		Region:      aws.String(r.AWSRegion),

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -96,7 +96,7 @@ func (d *Daemon) Loop(stop chan struct{}) {
 			d.config.Sync()
 			syncTimer.Reset(d.config.SyncInterval)
 		case <-syncTimer.C:
-			d.config.Logger.Info("Sync timer asking for sync")
+			d.config.Logger.V(1).Info("Sync timer asking for sync")
 			// request a new sync in the sync buffer. This might be a noop if a sync
 			// is already running.
 			d.askForSync()

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -19,7 +19,7 @@ type EnsureUserConfig struct {
 
 func EnsureUser(client *Client, log logr.Logger, config EnsureUserConfig, userName, rolename string) error {
 	users := make(map[string]struct{})
-	log.Info("listing iam policies")
+	log.V(1).Info("listing iam policies")
 	policies, err := client.ListPolicies()
 	if err != nil {
 		return err
@@ -42,7 +42,7 @@ func EnsureUser(client *Client, log logr.Logger, config EnsureUserConfig, userNa
 			// Try to update the document where the user is present to ensure correct roleName.
 			updated := policy.Document.Update(config.Region, config.AccountID, config.RolePrefix, userName, rolename)
 			if updated {
-				log.Info("updating policies for user", "userName", userName, "roleName", rolename)
+				log.V(1).Info("updating policies for user", "userName", userName, "roleName", rolename)
 				err = updatePolicies(client, policies)
 				if err != nil {
 					return err
@@ -55,7 +55,7 @@ func EnsureUser(client *Client, log logr.Logger, config EnsureUserConfig, userNa
 	} else {
 		for _, policy := range policies {
 			if policy.Document.Count() < config.MaxUsersPerPolicy {
-				log.Info("adding user to policy document", "userName", userName, "roleName", rolename)
+			log.V(1).Info("adding user to policy document", "userName", userName, "roleName", rolename)
 				policy.Document.Add(config.Region, config.AccountID, config.RolePrefix, userName, rolename)
 				err = updatePolicies(client, policies)
 				if err != nil {
@@ -69,7 +69,7 @@ func EnsureUser(client *Client, log logr.Logger, config EnsureUserConfig, userNa
 
 	// User could not be handled in an existing policy so we create a new one instead.
 	if !userHandled {
-		log.Info("creating a new policy document because of user", "userName", userName, "roleName", rolename)
+		log.V(1).Info("creating a new policy document because of user", "userName", userName, "roleName", rolename)
 		// TODO : There is a bug where where the new name might exist. This could for instance be the case where a policy i is deleted but i+1 exists. Then len(policies) = i+1 and there is a clash.
 		newPolicy := &Policy{
 			Name:     fmt.Sprintf("%s_%d", config.PolicyBaseName, len(policies)),

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -290,7 +290,7 @@ func setDefaultPrivileges(serviceConnection *sql.DB, serviceRole, readRole, read
 }
 
 func revokeAllOnPublic(log logr.Logger, serviceConnection *sql.DB, serviceCredentials Credentials) error {
-	log.Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", serviceCredentials.Name))
+	log.V(1).Info(fmt.Sprintf("Revoke ALL on role PUBLIC for database '%s'", serviceCredentials.Name))
 	err := execAsf(serviceConnection, serviceCredentials.User, `
 		REVOKE ALL ON DATABASE %s from PUBLIC;
 		REVOKE ALL ON SCHEMA public from PUBLIC;
@@ -303,13 +303,13 @@ func revokeAllOnPublic(log logr.Logger, serviceConnection *sql.DB, serviceCreden
 
 func grantConnectAndUsage(log logr.Logger, serviceConnection *sql.DB, serviceCredentials Credentials) error {
 	// Grant CONNECT privileges to PUBLIC again to ensure new roles are allowed to connect.
-	log.Info("Grant CONNECT to PUBLIC")
+	log.V(1).Info("Grant CONNECT to PUBLIC")
 	err := execAsf(serviceConnection, serviceCredentials.User, "GRANT CONNECT ON DATABASE %s TO PUBLIC", serviceCredentials.Name)
 	if err != nil {
 		return fmt.Errorf("grant connect to database '%s' to PUBLIC: %w as %s", serviceCredentials.Name, err, serviceCredentials.User)
 	}
 
-	log.Info(fmt.Sprintf("Grant usage on schema '%s' to PUBLIC", serviceCredentials.User))
+	log.V(1).Info(fmt.Sprintf("Grant usage on schema '%s' to PUBLIC", serviceCredentials.User))
 	err = execAsf(serviceConnection, serviceCredentials.User, "GRANT USAGE ON SCHEMA %s TO PUBLIC", serviceCredentials.User)
 	if err != nil {
 		return fmt.Errorf("grant usage on schema '%s' to PUBLIC: %w as %s", serviceCredentials.User, err, serviceCredentials.User)
@@ -331,9 +331,9 @@ func tryExec(log logr.Logger, db *sql.DB, args tryExecReq) error {
 		if !ok || pqError.Code.Name() != args.errorCode {
 			return err
 		}
-		log.Info(fmt.Sprintf("expected err '%s' occured. Ignoring for objectType '%s'", args.errorCode, args.objectType), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+		log.V(1).Info(fmt.Sprintf("expected err '%s' occured. Ignoring for objectType '%s'", args.errorCode, args.objectType), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
 	} else {
-		log.Info(fmt.Sprintf("%s created", args.objectType))
+		log.V(1).Info(fmt.Sprintf("%s created", args.objectType))
 	}
 	return nil
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -97,7 +97,7 @@ func (p Privilege) String() string {
 }
 
 func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []DatabaseSchema) error {
-	log.Info(fmt.Sprintf("Creating role %s", name))
+	log.V(1).Info(fmt.Sprintf("Creating role %s", name))
 	query := fmt.Sprintf("CREATE ROLE %s WITH LOGIN", name)
 	_, err := db.Exec(query)
 	if err != nil {
@@ -105,9 +105,9 @@ func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []
 		if !ok || pqError.Code.Name() != "duplicate_object" {
 			return fmt.Errorf("create role %s: %w", name, err)
 		}
-		log.Info(fmt.Sprintf("Role %s already exists", name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+		log.V(1).Info(fmt.Sprintf("Role %s already exists", name), "errorCode", pqError.Code, "errorName", pqError.Code.Name())
 	} else {
-		log.Info(fmt.Sprintf("Role %s created", name))
+		log.V(1).Info(fmt.Sprintf("Role %s created", name))
 	}
 
 	// grant database access roles to created role
@@ -116,7 +116,7 @@ func Role(log logr.Logger, db *sql.DB, name string, roles []string, databases []
 		return fmt.Errorf("get existing roles: %w", err)
 	}
 	grantableRoles, revokeableRoles := rolesDiff(log, existingRoles, roles, databases)
-	log.Info(fmt.Sprintf("Found %d grantable and %d revokable roles for %s", len(grantableRoles), len(revokeableRoles), name), "grantable", grantableRoles, "revokeable", revokeableRoles)
+	log.V(1).Info(fmt.Sprintf("Found %d grantable and %d revokable roles for %s", len(grantableRoles), len(revokeableRoles), name), "grantable", grantableRoles, "revokeable", revokeableRoles)
 	if len(grantableRoles) != 0 {
 		joinedRoles := strings.Join(grantableRoles, ",")
 		_, err = db.Exec(fmt.Sprintf("GRANT %s TO %s", joinedRoles, name))


### PR DESCRIPTION
Currently, the controller logs way too much, causing a unnecessary high logging cost.

This change reduces logs by either downgrading log statements or removing them.