### PR TITLE
Exclude rdsadmin database from customrole propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ spec:
 
 ### `grants`
 
-`grants` is a list of table privilege entries applied to every database on the host. Each entry has three fields:
+`grants` is a list of table privilege entries applied to every user database on the host. System databases (`postgres`, `rdsadmin`, and template databases) are excluded. Each entry has three fields:
 
 | Field | Description |
 |-------|-------------|

--- a/pkg/postgres/customrole.go
+++ b/pkg/postgres/customrole.go
@@ -420,11 +420,11 @@ func DropCustomRole(log logr.Logger, db *sql.DB, roleName string) error {
 }
 
 // UserDatabases returns the names of all non-template databases on the server,
-// excluding the postgres maintenance database.
+// excluding system databases (postgres, rdsadmin) and template databases.
 func UserDatabases(db *sql.DB) ([]string, error) {
 	rows, err := db.Query(`
 		SELECT datname FROM pg_database
-		WHERE datistemplate = false AND datname <> 'postgres'
+		WHERE datistemplate = false AND datname NOT IN ('postgres', 'rdsadmin')
 		ORDER BY datname`)
 	if err != nil {
 		return nil, fmt.Errorf("query databases: %w", err)

--- a/pkg/postgres/customrole_test.go
+++ b/pkg/postgres/customrole_test.go
@@ -769,6 +769,7 @@ func TestUserDatabases(t *testing.T) {
 
 	assert.Contains(t, databases, dbName, "created database should appear in list")
 	assert.NotContains(t, databases, "postgres", "postgres maintenance database should be excluded")
+	assert.NotContains(t, databases, "rdsadmin", "RDS internal database should be excluded")
 }
 
 func TestSyncDatabaseGrants_skipsMissingSchemaAndTable(t *testing.T) {


### PR DESCRIPTION
We need to exclude rdsadmin when applying custom roles. Firstly because we should not add roles here. Secondly because we do not have permission to do so.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change to database enumeration to skip the RDS internal `rdsadmin` database; main impact is reducing where grants are applied.
> 
> **Overview**
> Custom role table-grant propagation now **skips the AWS RDS internal `rdsadmin` database** by excluding it from `UserDatabases()`, preventing permission errors when reconciling grants.
> 
> Documentation and integration tests are updated to clarify that `grants` apply only to *user databases* and to assert `rdsadmin` is not included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e675d10be1bbecf79f06aeb8ab711c92e9033a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->