### PR TITLE
Skip permission-denied errors in CustomRole grant sync

### DIFF
--- a/pkg/postgres/customrole.go
+++ b/pkg/postgres/customrole.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,12 @@ import (
 
 	ctlerrors "go.lunarway.com/postgresql-controller/pkg/errors"
 )
+
+// isPermissionDenied returns true if err is a PostgreSQL insufficient_privilege error (SQLSTATE 42501).
+func isPermissionDenied(err error) bool {
+	var pqErr *pq.Error
+	return errors.As(err, &pqErr) && pqErr.Code == "42501"
+}
 
 // CustomRoleGrant defines schema/table privileges to apply to a role within a database.
 type CustomRoleGrant struct {
@@ -60,7 +67,7 @@ type grantKey struct {
 // The role is created with NOLOGIN.
 func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles []string) error {
 	log = log.WithValues("role", roleName)
-	log.V(1).Info("Ensuring custom role")
+	log.Info("Ensuring custom role")
 
 	_, err := db.Exec(fmt.Sprintf("CREATE ROLE %s NOLOGIN", pq.QuoteIdentifier(roleName)))
 	if err != nil {
@@ -68,9 +75,9 @@ func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles [
 		if !ok || pqError.Code.Name() != "duplicate_object" {
 			return fmt.Errorf("create role %s: %w", roleName, err)
 		}
-		log.V(1).Info("Role already exists", "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+		log.Info("Role already exists", "errorCode", pqError.Code, "errorName", pqError.Code.Name())
 	} else {
-		log.V(1).Info("Role created")
+		log.Info("Role created")
 	}
 
 	current, err := currentGrantedRoles(db, roleName)
@@ -90,7 +97,7 @@ func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles [
 			if err != nil {
 				return fmt.Errorf("revoke role %s from %s: %w", r, roleName, err)
 			}
-			log.V(1).Info("Revoked role", "role", r)
+			log.Info("Revoked role", "role", r)
 		}
 	}
 
@@ -116,7 +123,7 @@ func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles [
 	if err != nil {
 		return fmt.Errorf("grant roles %s to %s: %w", strings.Join(toGrant, ", "), roleName, err)
 	}
-	log.V(1).Info("Granted roles", "roles", toGrant)
+	log.Info("Granted roles", "roles", toGrant)
 	return nil
 }
 
@@ -192,9 +199,13 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 		if _, ok := currentSchemaSet[schema]; !ok {
 			if _, err := db.Exec(fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO %s",
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(roleName))); err != nil {
+				if isPermissionDenied(err) {
+					log.Info("Skipping schema USAGE grant: permission denied", "schema", schema, "role", roleName)
+					continue
+				}
 				return fmt.Errorf("grant usage on schema %s to %s: %w", schema, roleName, err)
 			}
-			log.V(1).Info("Granted USAGE on schema", "schema", schema)
+			log.Info("Granted USAGE on schema", "schema", schema)
 		}
 	}
 
@@ -213,9 +224,13 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 			pq.QuoteIdentifier(tk.schema),
 			pq.QuoteIdentifier(tk.table),
 			pq.QuoteIdentifier(roleName))); err != nil {
+			if isPermissionDenied(err) {
+				log.Info("Skipping table grant: permission denied", "schema", tk.schema, "table", tk.table, "privileges", privs, "role", roleName)
+				continue
+			}
 			return fmt.Errorf("grant %s on %s.%s to %s: %w", privList, tk.schema, tk.table, roleName, err)
 		}
-		log.V(1).Info("Granted privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
+		log.Info("Granted privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
 	}
 
 	// 3. Revoke removed table privileges, batched per (schema, table).
@@ -238,9 +253,13 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 			pq.QuoteIdentifier(tk.schema),
 			pq.QuoteIdentifier(tk.table),
 			pq.QuoteIdentifier(roleName))); err != nil {
+			if isPermissionDenied(err) {
+				log.Info("Skipping table revoke: permission denied", "schema", tk.schema, "table", tk.table, "privileges", privs, "role", roleName)
+				continue
+			}
 			return fmt.Errorf("revoke %s on %s.%s from %s: %w", privList, tk.schema, tk.table, roleName, err)
 		}
-		log.V(1).Info("Revoked privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
+		log.Info("Revoked privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
 	}
 
 	// 4. Revoke USAGE on schemas that no longer have any desired grants.
@@ -248,9 +267,13 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 		if _, ok := desiredSchemaSet[schema]; !ok {
 			if _, err := db.Exec(fmt.Sprintf("REVOKE USAGE ON SCHEMA %s FROM %s",
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(roleName))); err != nil {
+				if isPermissionDenied(err) {
+					log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
+					continue
+				}
 				return fmt.Errorf("revoke usage on schema %s from %s: %w", schema, roleName, err)
 			}
-			log.V(1).Info("Revoked USAGE on schema", "schema", schema)
+			log.Info("Revoked USAGE on schema", "schema", schema)
 		}
 	}
 
@@ -334,7 +357,7 @@ func expandGrants(log logr.Logger, db *sql.DB, grants []CustomRoleGrant) ([]gran
 			return nil, fmt.Errorf("resolve schemas: %w", err)
 		}
 		if len(schemas) == 0 {
-			log.V(1).Info("Schema not found in this database, skipping grant", "schema", grant.Schema)
+			log.Info("Schema not found in this database, skipping grant", "schema", grant.Schema)
 			continue
 		}
 		for _, schema := range schemas {
@@ -343,7 +366,7 @@ func expandGrants(log logr.Logger, db *sql.DB, grants []CustomRoleGrant) ([]gran
 				return nil, fmt.Errorf("resolve tables in schema %s: %w", schema, err)
 			}
 			if len(tables) == 0 && grant.Table != "" && grant.Table != "*" {
-				log.V(1).Info("Table not found in this database, skipping grant", "schema", schema, "table", grant.Table)
+				log.Info("Table not found in this database, skipping grant", "schema", schema, "table", grant.Table)
 				continue
 			}
 			for _, table := range tables {
@@ -398,12 +421,20 @@ func RevokeAllDatabaseGrants(log logr.Logger, db *sql.DB, roleName string) error
 	for _, schema := range schemas {
 		quotedSchema := pq.QuoteIdentifier(schema)
 		if _, err := db.Exec(fmt.Sprintf("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s", quotedSchema, quotedRole)); err != nil {
+			if isPermissionDenied(err) {
+				log.Info("Skipping bulk table revoke: permission denied", "schema", schema, "role", roleName)
+				continue
+			}
 			return fmt.Errorf("revoke table privileges on schema %s from %s: %w", schema, roleName, err)
 		}
 		if _, err := db.Exec(fmt.Sprintf("REVOKE USAGE ON SCHEMA %s FROM %s", quotedSchema, quotedRole)); err != nil {
+			if isPermissionDenied(err) {
+				log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
+				continue
+			}
 			return fmt.Errorf("revoke usage on schema %s from %s: %w", schema, roleName, err)
 		}
-		log.V(1).Info("Revoked schema grants", "schema", schema)
+		log.Info("Revoked schema grants", "schema", schema)
 	}
 	return nil
 }
@@ -415,7 +446,7 @@ func DropCustomRole(log logr.Logger, db *sql.DB, roleName string) error {
 	if _, err := db.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %s", pq.QuoteIdentifier(roleName))); err != nil {
 		return fmt.Errorf("drop role %s: %w", roleName, err)
 	}
-	log.V(1).Info("Dropped role")
+	log.Info("Dropped role")
 	return nil
 }
 

--- a/pkg/postgres/customrole.go
+++ b/pkg/postgres/customrole.go
@@ -421,20 +421,17 @@ func RevokeAllDatabaseGrants(log logr.Logger, db *sql.DB, roleName string) error
 	for _, schema := range schemas {
 		quotedSchema := pq.QuoteIdentifier(schema)
 		if _, err := db.Exec(fmt.Sprintf("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s", quotedSchema, quotedRole)); err != nil {
-			if isPermissionDenied(err) {
-				log.Info("Skipping bulk table revoke: permission denied", "schema", schema, "role", roleName)
-				continue
+			if !isPermissionDenied(err) {
+				return fmt.Errorf("revoke table privileges on schema %s from %s: %w", schema, roleName, err)
 			}
-			return fmt.Errorf("revoke table privileges on schema %s from %s: %w", schema, roleName, err)
+			log.Info("Skipping bulk table revoke: permission denied", "schema", schema, "role", roleName)
 		}
 		if _, err := db.Exec(fmt.Sprintf("REVOKE USAGE ON SCHEMA %s FROM %s", quotedSchema, quotedRole)); err != nil {
-			if isPermissionDenied(err) {
-				log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
-				continue
+			if !isPermissionDenied(err) {
+				return fmt.Errorf("revoke usage on schema %s from %s: %w", schema, roleName, err)
 			}
-			return fmt.Errorf("revoke usage on schema %s from %s: %w", schema, roleName, err)
+			log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
 		}
-		log.Info("Revoked schema grants", "schema", schema)
 	}
 	return nil
 }

--- a/pkg/postgres/customrole.go
+++ b/pkg/postgres/customrole.go
@@ -432,6 +432,7 @@ func RevokeAllDatabaseGrants(log logr.Logger, db *sql.DB, roleName string) error
 			}
 			log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
 		}
+		log.Info("Revoked schema grants", "schema", schema)
 	}
 	return nil
 }

--- a/pkg/postgres/customrole.go
+++ b/pkg/postgres/customrole.go
@@ -67,7 +67,7 @@ type grantKey struct {
 // The role is created with NOLOGIN.
 func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles []string) error {
 	log = log.WithValues("role", roleName)
-	log.Info("Ensuring custom role")
+	log.V(1).Info("Ensuring custom role")
 
 	_, err := db.Exec(fmt.Sprintf("CREATE ROLE %s NOLOGIN", pq.QuoteIdentifier(roleName)))
 	if err != nil {
@@ -75,9 +75,9 @@ func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles [
 		if !ok || pqError.Code.Name() != "duplicate_object" {
 			return fmt.Errorf("create role %s: %w", roleName, err)
 		}
-		log.Info("Role already exists", "errorCode", pqError.Code, "errorName", pqError.Code.Name())
+		log.V(1).Info("Role already exists", "errorCode", pqError.Code, "errorName", pqError.Code.Name())
 	} else {
-		log.Info("Role created")
+		log.V(1).Info("Role created")
 	}
 
 	current, err := currentGrantedRoles(db, roleName)
@@ -97,7 +97,7 @@ func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles [
 			if err != nil {
 				return fmt.Errorf("revoke role %s from %s: %w", r, roleName, err)
 			}
-			log.Info("Revoked role", "role", r)
+			log.V(1).Info("Revoked role", "role", r)
 		}
 	}
 
@@ -123,7 +123,7 @@ func EnsureCustomRole(log logr.Logger, db *sql.DB, roleName string, grantRoles [
 	if err != nil {
 		return fmt.Errorf("grant roles %s to %s: %w", strings.Join(toGrant, ", "), roleName, err)
 	}
-	log.Info("Granted roles", "roles", toGrant)
+	log.V(1).Info("Granted roles", "roles", toGrant)
 	return nil
 }
 
@@ -205,7 +205,7 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 				}
 				return fmt.Errorf("grant usage on schema %s to %s: %w", schema, roleName, err)
 			}
-			log.Info("Granted USAGE on schema", "schema", schema)
+			log.V(1).Info("Granted USAGE on schema", "schema", schema)
 		}
 	}
 
@@ -230,7 +230,7 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 			}
 			return fmt.Errorf("grant %s on %s.%s to %s: %w", privList, tk.schema, tk.table, roleName, err)
 		}
-		log.Info("Granted privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
+		log.V(1).Info("Granted privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
 	}
 
 	// 3. Revoke removed table privileges, batched per (schema, table).
@@ -259,7 +259,7 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 			}
 			return fmt.Errorf("revoke %s on %s.%s from %s: %w", privList, tk.schema, tk.table, roleName, err)
 		}
-		log.Info("Revoked privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
+		log.V(1).Info("Revoked privileges", "schema", tk.schema, "table", tk.table, "privileges", privs)
 	}
 
 	// 4. Revoke USAGE on schemas that no longer have any desired grants.
@@ -273,7 +273,7 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 				}
 				return fmt.Errorf("revoke usage on schema %s from %s: %w", schema, roleName, err)
 			}
-			log.Info("Revoked USAGE on schema", "schema", schema)
+			log.V(1).Info("Revoked USAGE on schema", "schema", schema)
 		}
 	}
 
@@ -357,7 +357,7 @@ func expandGrants(log logr.Logger, db *sql.DB, grants []CustomRoleGrant) ([]gran
 			return nil, fmt.Errorf("resolve schemas: %w", err)
 		}
 		if len(schemas) == 0 {
-			log.Info("Schema not found in this database, skipping grant", "schema", grant.Schema)
+			log.V(1).Info("Schema not found in this database, skipping grant", "schema", grant.Schema)
 			continue
 		}
 		for _, schema := range schemas {
@@ -366,7 +366,7 @@ func expandGrants(log logr.Logger, db *sql.DB, grants []CustomRoleGrant) ([]gran
 				return nil, fmt.Errorf("resolve tables in schema %s: %w", schema, err)
 			}
 			if len(tables) == 0 && grant.Table != "" && grant.Table != "*" {
-				log.Info("Table not found in this database, skipping grant", "schema", schema, "table", grant.Table)
+				log.V(1).Info("Table not found in this database, skipping grant", "schema", schema, "table", grant.Table)
 				continue
 			}
 			for _, table := range tables {
@@ -432,7 +432,7 @@ func RevokeAllDatabaseGrants(log logr.Logger, db *sql.DB, roleName string) error
 			}
 			log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
 		}
-		log.Info("Revoked schema grants", "schema", schema)
+		log.V(1).Info("Revoked schema grants", "schema", schema)
 	}
 	return nil
 }
@@ -444,7 +444,7 @@ func DropCustomRole(log logr.Logger, db *sql.DB, roleName string) error {
 	if _, err := db.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %s", pq.QuoteIdentifier(roleName))); err != nil {
 		return fmt.Errorf("drop role %s: %w", roleName, err)
 	}
-	log.Info("Dropped role")
+	log.V(1).Info("Dropped role")
 	return nil
 }
 

--- a/pkg/postgres/customrole_test.go
+++ b/pkg/postgres/customrole_test.go
@@ -832,6 +832,144 @@ func TestSyncDatabaseGrants_skipsMissingSchemaAndTable(t *testing.T) {
 	assert.True(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableName, "SELECT"), "existing table should still be granted")
 }
 
+// TestSyncDatabaseGrants_omittedSchemaAndTable_dbNamedSchema mimics a
+// production-like setup where:
+//   - The database is created via postgres.Database() (db-named schema)
+//   - Tables exist only in the db-named schema, not in public
+//   - The grant spec omits both schema and table (= wildcard all)
+//
+// Regression test for the hypothesis that omitted schema+table resolves to
+// zero matches instead of defaulting to all.
+func TestSyncDatabaseGrants_omittedSchemaAndTable_dbNamedSchema(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	dbName := fmt.Sprintf("test_%d", epoch)
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	tableName := fmt.Sprintf("tbl_%d", epoch)
+
+	// Create database the production way — this creates a db-named schema.
+	require.NoError(t, createManagerRole(log, adminDB, "postgres_role_name"))
+	require.NoError(t, postgres.Database(log, host,
+		postgres.Credentials{User: "iam_creator", Password: "iam_creator"},
+		postgres.Credentials{Name: dbName, User: dbName, Password: "test"},
+		"postgres_role_name", nil,
+	))
+
+	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer targetDB.Close()
+
+	// Create a table in the db-named schema (mimicking what an application does).
+	dbExec(t, targetDB, fmt.Sprintf("CREATE TABLE %s.%s (id int)", dbName, tableName))
+
+	// Verify public schema has no tables.
+	var publicTableCount int
+	require.NoError(t, targetDB.QueryRow(
+		"SELECT count(*) FROM pg_tables WHERE schemaname = 'public'",
+	).Scan(&publicTableCount))
+	require.Equal(t, 0, publicTableCount, "public schema should have no tables")
+
+	// Create the custom role and apply grants with both schema and table omitted.
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	err = postgres.SyncDatabaseGrants(log, targetDB, roleName, []postgres.CustomRoleGrant{
+		{Privileges: []string{"SELECT"}},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, schemaUsageGranted(t, targetDB, roleName, dbName),
+		"USAGE should be granted on the db-named schema")
+	assert.True(t, tablePrivilegeGranted(t, targetDB, roleName, dbName, tableName, "SELECT"),
+		"SELECT should be granted on the table in the db-named schema")
+}
+
+// TestSyncDatabaseGrants_skipsPermissionDenied verifies that when the
+// controller user does not have permission to grant on a table (e.g. it is
+// owned by another role), the grant is skipped with a warning rather than
+// failing the entire reconciliation. Tables the controller does own should
+// still be granted normally.
+func TestSyncDatabaseGrants_skipsPermissionDenied(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	dbName := fmt.Sprintf("test_%d", epoch)
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	controllerUser := fmt.Sprintf("controller_%d", epoch)
+	otherOwner := fmt.Sprintf("other_%d", epoch)
+	schemaName := fmt.Sprintf("schema_%d", epoch)
+	ownedTable := fmt.Sprintf("owned_%d", epoch)
+	unownedTable := fmt.Sprintf("unowned_%d", epoch)
+
+	// Set up the database.
+	require.NoError(t, createManagerRole(log, adminDB, "postgres_role_name"))
+	require.NoError(t, postgres.Database(log, host,
+		postgres.Credentials{User: "iam_creator", Password: "iam_creator"},
+		postgres.Credentials{Name: dbName, User: dbName, Password: "test"},
+		"postgres_role_name", nil,
+	))
+
+	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer targetDB.Close()
+
+	// Create non-superuser roles: one acts as the controller, the other owns an inaccessible table.
+	dbExec(t, adminDB, fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", controllerUser, controllerUser))
+	dbExec(t, adminDB, fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", otherOwner, otherOwner))
+
+	// Create schema owned by the controller so it can grant USAGE.
+	dbExec(t, targetDB, fmt.Sprintf("CREATE SCHEMA %s AUTHORIZATION %s", schemaName, controllerUser))
+
+	// Create two tables: one owned by the controller, one by another role.
+	dbExec(t, targetDB, fmt.Sprintf("CREATE TABLE %s.%s (id int)", schemaName, ownedTable))
+	dbExec(t, targetDB, fmt.Sprintf("CREATE TABLE %s.%s (id int)", schemaName, unownedTable))
+	dbExec(t, targetDB, fmt.Sprintf("ALTER TABLE %s.%s OWNER TO %s", schemaName, ownedTable, controllerUser))
+	dbExec(t, targetDB, fmt.Sprintf("ALTER TABLE %s.%s OWNER TO %s", schemaName, unownedTable, otherOwner))
+
+	// Create the custom role on the admin database.
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	// Connect as the controller — it owns the schema and one table but not the other.
+	controllerDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: controllerUser, Password: controllerUser,
+	})
+	require.NoError(t, err)
+	defer controllerDB.Close()
+
+	// SyncDatabaseGrants should skip the unowned table and succeed on the owned one.
+	err = postgres.SyncDatabaseGrants(log, controllerDB, roleName, []postgres.CustomRoleGrant{
+		{Schema: schemaName, Table: ownedTable, Privileges: []string{"SELECT"}},
+		{Schema: schemaName, Table: unownedTable, Privileges: []string{"SELECT"}},
+	})
+	require.NoError(t, err, "permission denied should be skipped, not returned as error")
+
+	// Verify owned table got the grant.
+	assert.True(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, ownedTable, "SELECT"),
+		"privilege should be granted on the owned table")
+
+	// Verify unowned table was skipped.
+	assert.False(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, unownedTable, "SELECT"),
+		"privilege should not have been granted on the unowned table")
+}
+
 // roleExists returns true if a role with the given name exists in pg_roles.
 func roleExists(t *testing.T, db *sql.DB, roleName string) bool {
 	t.Helper()


### PR DESCRIPTION
## Summary
- When the controller user lacks permission to GRANT/REVOKE on a table (e.g. owned by another role), the error is now logged as a warning and skipped instead of failing the entire reconciliation
- Previously, a single permission-denied error on any table in any database would block all grant processing across all databases, resulting in zero grants being applied
- Also promotes all customrole log messages from V(1) to V(0) for visibility at the default log level

## Test plan
- [ ] New integration test `TestSyncDatabaseGrants_skipsPermissionDenied` covers the scenario: controller owns one table but not another, verifies the owned table gets the grant while the unowned table is skipped without error
- [ ] Existing integration tests continue to pass
- [ ] Deploy to staging and verify grants appear in logs and are applied to accessible tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconciliation behavior to ignore SQLSTATE 42501 on GRANT/REVOKE, which may leave some privileges unsynced if permissions are misconfigured, but prevents one inaccessible object from blocking all grant processing.
> 
> **Overview**
> Custom role database grant reconciliation now *skips* `insufficient_privilege` (SQLSTATE `42501`) errors when granting/revoking schema `USAGE` and table privileges, logging the skip instead of failing the entire sync (including in `RevokeAllDatabaseGrants`).
> 
> All `customrole` logs were promoted from `V(1)` to default `Info` for better visibility, and new integration tests cover wildcard grants in db-named schemas plus the permission-denied skip behavior (owned vs unowned tables).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0de0acee7077b7eca4c792d7cd7fb37876d655. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->