### PR TITLE
Fix CustomRole grants not persisting (SET ROLE to table owner)

### DIFF
--- a/pkg/postgres/customrole.go
+++ b/pkg/postgres/customrole.go
@@ -154,6 +154,10 @@ func currentGrantedRoles(db *sql.DB, roleName string) ([]string, error) {
 // currently-connected database to exactly match grants. It computes the diff
 // between current and desired (schema, table, privilege) tuples and issues only
 // the necessary GRANT/REVOKE statements, avoiding any access outage window.
+//
+// GRANT/REVOKE statements are executed with SET ROLE to the object owner so
+// that they succeed even when the controller's connection role (e.g.
+// iam_creator) does not directly own the objects.
 func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []CustomRoleGrant) error {
 	for _, g := range grants {
 		if err := validatePrivileges(g.Privileges); err != nil {
@@ -192,12 +196,28 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 		desiredSchemaSet[g.schema] = struct{}{}
 	}
 
+	// Look up object owners so we can SET ROLE before GRANT/REVOKE.
+	schemaOwners, err := schemaOwnerMap(db)
+	if err != nil {
+		return err
+	}
+	tblOwners, err := tableOwnerMap(db)
+	if err != nil {
+		return err
+	}
+
 	type tableKey struct{ schema, table string }
 
 	// 1. Grant USAGE on schemas not yet accessible.
 	for schema := range desiredSchemaSet {
 		if _, ok := currentSchemaSet[schema]; !ok {
-			if _, err := db.Exec(fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO %s",
+			owner, ok := schemaOwners[schema]
+			if !ok {
+				log.Info("Skipping schema USAGE grant: owner not found", "schema", schema, "role", roleName)
+				continue
+			}
+			if _, err := db.Exec(fmt.Sprintf("SET ROLE %s; GRANT USAGE ON SCHEMA %s TO %s; RESET ROLE",
+				pq.QuoteIdentifier(owner),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(roleName))); err != nil {
 				if isPermissionDenied(err) {
 					log.Info("Skipping schema USAGE grant: permission denied", "schema", schema, "role", roleName)
@@ -218,8 +238,14 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 		}
 	}
 	for tk, privs := range toGrant {
+		owner := tblOwners[tk.schema][tk.table]
+		if owner == "" {
+			log.Info("Skipping table grant: owner not found", "schema", tk.schema, "table", tk.table, "privileges", privs, "role", roleName)
+			continue
+		}
 		privList := strings.Join(privs, ", ")
-		if _, err := db.Exec(fmt.Sprintf("GRANT %s ON TABLE %s.%s TO %s",
+		if _, err := db.Exec(fmt.Sprintf("SET ROLE %s; GRANT %s ON TABLE %s.%s TO %s; RESET ROLE",
+			pq.QuoteIdentifier(owner),
 			privList,
 			pq.QuoteIdentifier(tk.schema),
 			pq.QuoteIdentifier(tk.table),
@@ -247,8 +273,14 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 				log.Info("Revoking unrecognized privilege type from database catalog", "privilege", p, "schema", tk.schema, "table", tk.table)
 			}
 		}
+		owner := tblOwners[tk.schema][tk.table]
+		if owner == "" {
+			log.Info("Skipping table revoke: owner not found", "schema", tk.schema, "table", tk.table, "privileges", privs, "role", roleName)
+			continue
+		}
 		privList := strings.Join(privs, ", ")
-		if _, err := db.Exec(fmt.Sprintf("REVOKE %s ON TABLE %s.%s FROM %s",
+		if _, err := db.Exec(fmt.Sprintf("SET ROLE %s; REVOKE %s ON TABLE %s.%s FROM %s; RESET ROLE",
+			pq.QuoteIdentifier(owner),
 			privList,
 			pq.QuoteIdentifier(tk.schema),
 			pq.QuoteIdentifier(tk.table),
@@ -265,7 +297,13 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 	// 4. Revoke USAGE on schemas that no longer have any desired grants.
 	for _, schema := range currentSchemas {
 		if _, ok := desiredSchemaSet[schema]; !ok {
-			if _, err := db.Exec(fmt.Sprintf("REVOKE USAGE ON SCHEMA %s FROM %s",
+			owner, ok := schemaOwners[schema]
+			if !ok {
+				log.Info("Skipping schema USAGE revoke: owner not found", "schema", schema, "role", roleName)
+				continue
+			}
+			if _, err := db.Exec(fmt.Sprintf("SET ROLE %s; REVOKE USAGE ON SCHEMA %s FROM %s; RESET ROLE",
+				pq.QuoteIdentifier(owner),
 				pq.QuoteIdentifier(schema), pq.QuoteIdentifier(roleName))); err != nil {
 				if isPermissionDenied(err) {
 					log.Info("Skipping schema USAGE revoke: permission denied", "schema", schema, "role", roleName)
@@ -278,6 +316,53 @@ func SyncDatabaseGrants(log logr.Logger, db *sql.DB, roleName string, grants []C
 	}
 
 	return nil
+}
+
+// schemaOwnerMap returns a map of schema name to its owner role name for all
+// user-defined schemas in the currently-connected database.
+func schemaOwnerMap(db *sql.DB) (map[string]string, error) {
+	rows, err := db.Query(`
+		SELECT n.nspname, r.rolname
+		FROM pg_namespace n
+		JOIN pg_roles r ON r.oid = n.nspowner
+		WHERE n.nspname NOT LIKE 'pg_%' AND n.nspname <> 'information_schema'`)
+	if err != nil {
+		return nil, fmt.Errorf("query schema owners: %w", err)
+	}
+	defer rows.Close()
+	owners := make(map[string]string)
+	for rows.Next() {
+		var schema, owner string
+		if err := rows.Scan(&schema, &owner); err != nil {
+			return nil, fmt.Errorf("scan schema owner: %w", err)
+		}
+		owners[schema] = owner
+	}
+	return owners, rows.Err()
+}
+
+// tableOwnerMap returns a nested map of schema -> table -> owner role name
+// for all user-defined tables in the currently-connected database.
+func tableOwnerMap(db *sql.DB) (map[string]map[string]string, error) {
+	rows, err := db.Query(`
+		SELECT schemaname, tablename, tableowner FROM pg_tables
+		WHERE schemaname NOT LIKE 'pg_%' AND schemaname <> 'information_schema'`)
+	if err != nil {
+		return nil, fmt.Errorf("query table owners: %w", err)
+	}
+	defer rows.Close()
+	owners := make(map[string]map[string]string)
+	for rows.Next() {
+		var schema, table, owner string
+		if err := rows.Scan(&schema, &table, &owner); err != nil {
+			return nil, fmt.Errorf("scan table owner: %w", err)
+		}
+		if owners[schema] == nil {
+			owners[schema] = make(map[string]string)
+		}
+		owners[schema][table] = owner
+	}
+	return owners, rows.Err()
 }
 
 // currentTableGrants returns all table privileges held by roleName in the
@@ -417,16 +502,50 @@ func RevokeAllDatabaseGrants(log logr.Logger, db *sql.DB, roleName string) error
 	if err != nil {
 		return err
 	}
+	schemaOwners, err := schemaOwnerMap(db)
+	if err != nil {
+		return err
+	}
+	tblOwners, err := tableOwnerMap(db)
+	if err != nil {
+		return err
+	}
 	quotedRole := pq.QuoteIdentifier(roleName)
 	for _, schema := range schemas {
 		quotedSchema := pq.QuoteIdentifier(schema)
-		if _, err := db.Exec(fmt.Sprintf("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s", quotedSchema, quotedRole)); err != nil {
-			if !isPermissionDenied(err) {
-				return fmt.Errorf("revoke table privileges on schema %s from %s: %w", schema, roleName, err)
-			}
-			log.Info("Skipping bulk table revoke: permission denied", "schema", schema, "role", roleName)
+
+		// Collect unique table owners for this schema so the bulk revoke
+		// covers tables regardless of which role owns them.
+		owners := make(map[string]struct{})
+		for _, owner := range tblOwners[schema] {
+			owners[owner] = struct{}{}
 		}
-		if _, err := db.Exec(fmt.Sprintf("REVOKE USAGE ON SCHEMA %s FROM %s", quotedSchema, quotedRole)); err != nil {
+		if owner, ok := schemaOwners[schema]; ok {
+			owners[owner] = struct{}{}
+		}
+
+		if len(owners) == 0 {
+			log.Info("Skipping schema revoke: no owners found", "schema", schema, "role", roleName)
+			continue
+		}
+
+		for owner := range owners {
+			quotedOwner := pq.QuoteIdentifier(owner)
+			if _, err := db.Exec(fmt.Sprintf("SET ROLE %s; REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s; RESET ROLE",
+				quotedOwner, quotedSchema, quotedRole)); err != nil {
+				if !isPermissionDenied(err) {
+					return fmt.Errorf("revoke table privileges on schema %s from %s: %w", schema, roleName, err)
+				}
+				log.Info("Skipping bulk table revoke: permission denied", "schema", schema, "owner", owner, "role", roleName)
+			}
+		}
+
+		schemaOwner, ok := schemaOwners[schema]
+		if !ok {
+			continue
+		}
+		if _, err := db.Exec(fmt.Sprintf("SET ROLE %s; REVOKE USAGE ON SCHEMA %s FROM %s; RESET ROLE",
+			pq.QuoteIdentifier(schemaOwner), quotedSchema, quotedRole)); err != nil {
 			if !isPermissionDenied(err) {
 				return fmt.Errorf("revoke usage on schema %s from %s: %w", schema, roleName, err)
 			}

--- a/pkg/postgres/customrole_test.go
+++ b/pkg/postgres/customrole_test.go
@@ -970,6 +970,185 @@ func TestSyncDatabaseGrants_skipsPermissionDenied(t *testing.T) {
 		"privilege should not have been granted on the unowned table")
 }
 
+// TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner verifies that when the
+// controller connects as a user that does NOT own the tables but IS a member of
+// the table-owning role, GRANT and REVOKE succeed via SET ROLE.
+// This mirrors production: iam_creator (rds_superuser member) must SET ROLE to
+// the service user to modify grants on service-owned tables.
+func TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	dbName := fmt.Sprintf("test_%d", epoch)
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	serviceUser := fmt.Sprintf("svc_%d", epoch)
+	controllerUser := fmt.Sprintf("ctrl_%d", epoch)
+	schemaName := fmt.Sprintf("schema_%d", epoch)
+	tableA := fmt.Sprintf("table_a_%d", epoch)
+	tableB := fmt.Sprintf("table_b_%d", epoch)
+
+	// Create the database.
+	require.NoError(t, createManagerRole(log, adminDB, "postgres_role_name"))
+	require.NoError(t, postgres.Database(log, host,
+		postgres.Credentials{User: "iam_creator", Password: "iam_creator"},
+		postgres.Credentials{Name: dbName, User: dbName, Password: "test"},
+		"postgres_role_name", nil,
+	))
+
+	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer targetDB.Close()
+
+	// Create a service user that owns the schema and tables, and a controller
+	// user that is a member of the service user (like rds_superuser → service user).
+	dbExec(t, adminDB, fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", serviceUser, serviceUser))
+	dbExec(t, adminDB, fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", controllerUser, controllerUser))
+	// Grant membership with SET but NOT INHERIT. This mirrors production where
+	// iam_creator (rds_superuser) can SET ROLE to service users but does not
+	// inherit their ownership privileges. Without SET ROLE in the code, GRANT
+	// on service-owned objects will fail with permission denied.
+	dbExec(t, adminDB, fmt.Sprintf("GRANT %s TO %s WITH SET TRUE, INHERIT FALSE", serviceUser, controllerUser))
+	// Grant CONNECT so the controller can connect to the database.
+	dbExec(t, targetDB, fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s", dbName, controllerUser))
+
+	// Create schema and tables owned by the service user.
+	dbExec(t, targetDB, fmt.Sprintf("CREATE SCHEMA %s AUTHORIZATION %s", schemaName, serviceUser))
+	serviceDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: serviceUser, Password: serviceUser,
+	})
+	require.NoError(t, err)
+	defer serviceDB.Close()
+	dbExec(t, serviceDB, fmt.Sprintf("CREATE TABLE %s.%s (id int)", schemaName, tableA))
+	dbExec(t, serviceDB, fmt.Sprintf("CREATE TABLE %s.%s (id int)", schemaName, tableB))
+
+	// Verify the tables are owned by the service user, not the controller.
+	var owner string
+	require.NoError(t, targetDB.QueryRow(
+		"SELECT tableowner FROM pg_tables WHERE schemaname = $1 AND tablename = $2",
+		schemaName, tableA).Scan(&owner))
+	require.Equal(t, serviceUser, owner, "table should be owned by service user")
+
+	// Create the custom role.
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	// Connect as the controller user (member of service user, but not the table owner).
+	controllerDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: controllerUser, Password: controllerUser,
+	})
+	require.NoError(t, err)
+	defer controllerDB.Close()
+
+	// SyncDatabaseGrants should succeed via SET ROLE to the table owner.
+	err = postgres.SyncDatabaseGrants(log, controllerDB, roleName, []postgres.CustomRoleGrant{
+		{Schema: schemaName, Privileges: []string{"SELECT"}},
+	})
+	require.NoError(t, err, "grant should succeed via SET ROLE to table owner")
+
+	// Verify the grants were actually applied (check from adminDB to avoid any session effects).
+	assert.True(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableA, "SELECT"),
+		"SELECT should be granted on tableA owned by service user")
+	assert.True(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableB, "SELECT"),
+		"SELECT should be granted on tableB owned by service user")
+	assert.True(t, schemaUsageGranted(t, targetDB, roleName, schemaName),
+		"USAGE should be granted on schema owned by service user")
+
+	// Verify revoke also works via SET ROLE: sync with no grants.
+	err = postgres.SyncDatabaseGrants(log, controllerDB, roleName, nil)
+	require.NoError(t, err, "revoke should succeed via SET ROLE to table owner")
+
+	assert.False(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableA, "SELECT"),
+		"SELECT should be revoked from tableA")
+	assert.False(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableB, "SELECT"),
+		"SELECT should be revoked from tableB")
+	assert.False(t, schemaUsageGranted(t, targetDB, roleName, schemaName),
+		"USAGE on schema should be revoked")
+}
+
+// TestRevokeAllDatabaseGrants_viaSetRole verifies that RevokeAllDatabaseGrants
+// succeeds when the connection user is a member of the table owner, relying on
+// SET ROLE to perform the revocations.
+func TestRevokeAllDatabaseGrants_viaSetRole(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	dbName := fmt.Sprintf("test_%d", epoch)
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	serviceUser := fmt.Sprintf("svc_%d", epoch)
+	controllerUser := fmt.Sprintf("ctrl_%d", epoch)
+	schemaName := fmt.Sprintf("schema_%d", epoch)
+	tableName := fmt.Sprintf("table_%d", epoch)
+
+	require.NoError(t, createManagerRole(log, adminDB, "postgres_role_name"))
+	require.NoError(t, postgres.Database(log, host,
+		postgres.Credentials{User: "iam_creator", Password: "iam_creator"},
+		postgres.Credentials{Name: dbName, User: dbName, Password: "test"},
+		"postgres_role_name", nil,
+	))
+
+	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer targetDB.Close()
+
+	dbExec(t, adminDB, fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", serviceUser, serviceUser))
+	dbExec(t, adminDB, fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", controllerUser, controllerUser))
+	// Grant membership with SET but NOT INHERIT, mirroring production where
+	// the controller can SET ROLE but does not inherit ownership privileges.
+	dbExec(t, adminDB, fmt.Sprintf("GRANT %s TO %s WITH SET TRUE, INHERIT FALSE", serviceUser, controllerUser))
+	dbExec(t, targetDB, fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s", dbName, controllerUser))
+
+	// Create schema and table owned by the service user.
+	dbExec(t, targetDB, fmt.Sprintf("CREATE SCHEMA %s AUTHORIZATION %s", schemaName, serviceUser))
+	serviceDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: serviceUser, Password: serviceUser,
+	})
+	require.NoError(t, err)
+	defer serviceDB.Close()
+	dbExec(t, serviceDB, fmt.Sprintf("CREATE TABLE %s.%s (id int)", schemaName, tableName))
+
+	// Create custom role and grant privileges via SET ROLE.
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	controllerDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: dbName, User: controllerUser, Password: controllerUser,
+	})
+	require.NoError(t, err)
+	defer controllerDB.Close()
+
+	err = postgres.SyncDatabaseGrants(log, controllerDB, roleName, []postgres.CustomRoleGrant{
+		{Schema: schemaName, Privileges: []string{"SELECT"}},
+	})
+	require.NoError(t, err)
+	require.True(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableName, "SELECT"),
+		"precondition: grant should be in place before revoke test")
+
+	// RevokeAllDatabaseGrants should succeed via SET ROLE.
+	err = postgres.RevokeAllDatabaseGrants(log, controllerDB, roleName)
+	require.NoError(t, err, "RevokeAllDatabaseGrants should succeed via SET ROLE")
+
+	assert.False(t, tablePrivilegeGranted(t, targetDB, roleName, schemaName, tableName, "SELECT"),
+		"SELECT should be revoked")
+	assert.False(t, schemaUsageGranted(t, targetDB, roleName, schemaName),
+		"USAGE should be revoked")
+}
+
 // roleExists returns true if a role with the given name exists in pg_roles.
 func roleExists(t *testing.T, db *sql.DB, roleName string) bool {
 	t.Helper()


### PR DESCRIPTION
## Summary

- `SyncDatabaseGrants` and `RevokeAllDatabaseGrants` ran GRANT/REVOKE as `iam_creator`, which does not own the tables (service users like `transactionrepo` do). PostgreSQL requires the table owner to issue grants, so all grants silently failed.
- Added `SET ROLE <owner>` before each GRANT/REVOKE statement and `RESET ROLE` after, matching the pattern used by the PostgreSQLDatabase controller's `execAsf`/`prependSetRole`.
- Added `schemaOwnerMap()` and `tableOwnerMap()` helpers to bulk-query object ownership from `pg_namespace` and `pg_tables`.

## Test plan

- [x] Added `TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner` — verifies GRANT and REVOKE succeed when connection user is a member of the table owner (SET only, no INHERIT)
- [x] Added `TestRevokeAllDatabaseGrants_viaSetRole` — verifies `RevokeAllDatabaseGrants` works via SET ROLE
- [x] Verified new tests **fail without the fix** (grants skipped with "permission denied") and **pass with the fix**
- [x] All 23 existing CustomRole integration tests still pass

The key to making the test realistic was `GRANT serviceUser TO controllerUser WITH SET TRUE, INHERIT FALSE`. This mirrors production where `iam_creator` can SET ROLE to service users (via `rds_superuser`) but doesn't inherit their ownership privileges. Without `INHERIT FALSE`, PostgreSQL 18 lets members exercise all owner privileges including granting, which would mask the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database privilege management logic and changes how SQL is executed (`SET ROLE`), which can impact access control behavior if owner detection or role membership is misconfigured.
> 
> **Overview**
> Ensures `SyncDatabaseGrants` applies and removes schema/table privileges by first resolving schema/table owners and wrapping each GRANT/REVOKE (including schema USAGE) in `SET ROLE <owner> ... RESET ROLE`, so the controller can manage privileges on objects it doesn’t directly own.
> 
> Updates `RevokeAllDatabaseGrants` to revoke table privileges under **all unique table owners in a schema** (not just the schema owner), and adds integration tests covering `SET ROLE` behavior with `INHERIT FALSE` membership to match production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03332c870d964c405907e57af225335d161a42d5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->