### PR TITLE
Revoke default PUBLIC EXECUTE on SECURITY DEFINER functions

### DIFF
--- a/pkg/postgres/customrole_functions.go
+++ b/pkg/postgres/customrole_functions.go
@@ -262,6 +262,18 @@ func SyncDatabaseFunctions(log logr.Logger, db *sql.DB, roleName string, functio
 			return fmt.Errorf("set owner on function %s: %w", qualifiedName, err)
 		}
 
+		// Revoke the default PUBLIC EXECUTE grant so only roleName can call the
+		// function. PostgreSQL grants EXECUTE to PUBLIC by default on new
+		// functions, which would otherwise let any role invoke a SECURITY
+		// DEFINER function owned by a privileged role.
+		if err := execWithRole(db, owner, func(tx *sql.Tx) error {
+			_, err := tx.Exec(fmt.Sprintf("REVOKE ALL ON FUNCTION public.%s(%s) FROM PUBLIC",
+				pq.QuoteIdentifier(pgName), canonicalArgs))
+			return err
+		}); err != nil {
+			return fmt.Errorf("revoke public execute on %s: %w", qualifiedName, err)
+		}
+
 		if err := execWithRole(db, owner, func(tx *sql.Tx) error {
 			_, err := tx.Exec(fmt.Sprintf("GRANT EXECUTE ON FUNCTION public.%s(%s) TO %s",
 				pq.QuoteIdentifier(pgName), canonicalArgs, quotedRole))

--- a/pkg/postgres/customrole_functions_test.go
+++ b/pkg/postgres/customrole_functions_test.go
@@ -274,6 +274,32 @@ func TestSyncDatabaseFunctions_securityDefiner(t *testing.T) {
 	assert.Equal(t, "true", securityType, "function should be SECURITY DEFINER")
 }
 
+func TestSyncDatabaseFunctions_revokesPublicExecute(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	pgName := fmt.Sprintf("custom_role_%d__myfunc", epoch)
+
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	require.NoError(t, postgres.SyncDatabaseFunctions(log, adminDB, roleName, []postgres.CustomRoleFunction{
+		{Name: "myfunc", Returns: "void", Body: "NULL;"},
+	}))
+
+	assert.True(t, functionExecuteGranted(t, adminDB, roleName, "public", pgName),
+		"role should have EXECUTE on function")
+	assert.False(t, functionPublicExecuteGranted(t, adminDB, "public", pgName),
+		"PUBLIC should not have EXECUTE on SECURITY DEFINER function")
+}
+
 // functionExists returns true if a function with the given name exists in the schema.
 func functionExists(t *testing.T, db *sql.DB, schema, funcName string) bool {
 	t.Helper()
@@ -301,6 +327,26 @@ func functionExecuteGranted(t *testing.T, db *sql.DB, roleName, schema, funcName
 			  AND a.grantee = (SELECT oid FROM pg_roles WHERE rolname = $3)
 			  AND a.privilege_type = 'EXECUTE'
 		)`, schema, funcName, roleName).Scan(&granted)
+	require.NoError(t, err)
+	return granted
+}
+
+// functionPublicExecuteGranted returns true if PUBLIC has EXECUTE on a function
+// in the given schema. When proacl is NULL, PostgreSQL applies default privileges
+// which include EXECUTE to PUBLIC; that case is handled via COALESCE to the
+// default ACL for the function's owner.
+func functionPublicExecuteGranted(t *testing.T, db *sql.DB, schema, funcName string) bool {
+	t.Helper()
+	var granted bool
+	err := db.QueryRow(`
+		SELECT EXISTS(
+			SELECT 1 FROM pg_proc p
+			JOIN pg_namespace n ON n.oid = p.pronamespace,
+			     aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) AS a(grantor, grantee, privilege_type, is_grantable)
+			WHERE n.nspname = $1 AND p.proname = $2
+			  AND a.grantee = 0
+			  AND a.privilege_type = 'EXECUTE'
+		)`, schema, funcName).Scan(&granted)
 	require.NoError(t, err)
 	return granted
 }


### PR DESCRIPTION
## Summary

- PostgreSQL grants `EXECUTE` to `PUBLIC` by default on every new function. For CustomRole-managed SECURITY DEFINER functions (which typically run as an elevated owner like `rds_superuser` or `rds_pgaudit`), this meant any role on the cluster could invoke them — only the internal predicate checks (if any) stood between an arbitrary caller and the elevated action.
- Emit `REVOKE ALL ON FUNCTION ... FROM PUBLIC` as the function owner before the existing `GRANT EXECUTE TO <roleName>` so only the owning CustomRole (and roles granted membership in it) can call the function.
- The REVOKE runs via `execWithRole` like the surrounding DDL and is idempotent, so re-syncs stay consistent.

## Test plan

- [x] `go build ./...` and `go vet ./pkg/postgres/...`
- [x] `POSTGRESQL_CONTROLLER_INTEGRATION_HOST=localhost:5432 go test ./pkg/postgres/` (full package, all pass)
- [x] New integration test `TestSyncDatabaseFunctions_revokesPublicExecute` asserts PUBLIC has no EXECUTE after sync while the target role still does
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database privilege/ACL logic for SECURITY DEFINER functions; a mistake could break callers or unintentionally change access, though the change is narrowly scoped and covered by a new integration test.
> 
> **Overview**
> `SyncDatabaseFunctions` now runs `REVOKE ALL ON FUNCTION ... FROM PUBLIC` (as the function owner) after ensuring ownership, removing PostgreSQL’s default `PUBLIC` EXECUTE grant on newly created SECURITY DEFINER functions before re-granting `EXECUTE` to the managed custom role.
> 
> Adds an integration test asserting the target role retains `EXECUTE` while `PUBLIC` does not, including a helper that correctly detects implicit default ACLs when `proacl` is `NULL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb912581ad88fd8e2bcd48ed5d89403923aded9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->