### PR TITLE
feat: add $controllerUser sentinel for CustomRole function owningRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,31 @@ spec:
 
 Valid privilege keywords: `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `REFERENCES`, `TRIGGER`.
 
+### `functions`
+
+`functions` is a list of SECURITY DEFINER functions created in the `public` schema with `LANGUAGE plpgsql` and `SET search_path = pg_catalog`. The `body` field contains only the PL/pgSQL statements; `BEGIN`/`END` is added automatically.
+
+Each function entry supports an optional `owningRole` field that controls which role owns (and therefore executes as) the function:
+
+| `owningRole` value | Effective owner |
+|--------------------|-----------------|
+| omitted / empty | Database owner (default, least privilege) |
+| a literal role name | That specific role |
+| `$controllerUser` | The controller's current connection role |
+
+Use `$controllerUser` when the controller's admin role differs across hosts (e.g. `iam_creator` on one cluster, `iam_creator_v2` on another), or when the target owner is `rds_superuser` on AWS RDS — that role blocks `SET ROLE` even with `set_option=t`, so a literal name would fail on RDS hosts.
+
+```yaml
+spec:
+  functions:
+    - name: my_admin_function
+      args: "target_role text"
+      returns: void
+      owningRole: $controllerUser
+      body: |
+        EXECUTE format('ALTER ROLE %I SET some_setting = %L', target_role, 'value');
+```
+
 ### Examples
 
 #### Read-only role across all schemas and tables

--- a/api/v1alpha1/customrole_types.go
+++ b/api/v1alpha1/customrole_types.go
@@ -86,6 +86,8 @@ type CustomRoleGrant struct {
 // By default the function is owned by the database owner, so SECURITY DEFINER
 // runs with that role's privileges. Set owningRole to override this (e.g. to
 // use a superuser role for functions that need elevated privileges like ALTER ROLE).
+// Use the sentinel value "$controller" to resolve to the controller's connection
+// role at reconcile time — recommended when the connection role differs per host.
 //
 // Example:
 //
@@ -112,6 +114,14 @@ type CustomRoleFunction struct {
 	// OwningRole is the PostgreSQL role that will own the function. Since the
 	// function uses SECURITY DEFINER, it executes with this role's privileges.
 	// If omitted, the function is owned by the database owner.
+	//
+	// Special sentinel values:
+	//   - "$controller" — resolves at reconcile time to the role the controller
+	//     is currently connected as (SELECT current_user). Use this when the
+	//     connection role differs per host (e.g. iam_creator, iam_creator_v2)
+	//     and hard-coding a role name is not viable. This is the recommended
+	//     value when the function must be owned by the controller's connection role.
+	//
 	// +optional
 	OwningRole string `json:"owningRole,omitempty"`
 

--- a/api/v1alpha1/customrole_types.go
+++ b/api/v1alpha1/customrole_types.go
@@ -162,7 +162,7 @@ type CustomRoleStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Role",type="string",JSONPath=".metadata.name"
+// +kubebuilder:printcolumn:name="Role",type="string",JSONPath=".spec.roleName"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.error"
 

--- a/api/v1alpha1/customrole_types.go
+++ b/api/v1alpha1/customrole_types.go
@@ -86,7 +86,7 @@ type CustomRoleGrant struct {
 // By default the function is owned by the database owner, so SECURITY DEFINER
 // runs with that role's privileges. Set owningRole to override this (e.g. to
 // use a superuser role for functions that need elevated privileges like ALTER ROLE).
-// Use the sentinel value "$controller" to resolve to the controller's connection
+// Use the sentinel value "$controllerUser" to resolve to the controller's connection
 // role at reconcile time — recommended when the connection role differs per host.
 //
 // Example:
@@ -116,7 +116,7 @@ type CustomRoleFunction struct {
 	// If omitted, the function is owned by the database owner.
 	//
 	// Special sentinel values:
-	//   - "$controller" — resolves at reconcile time to the role the controller
+	//   - "$controllerUser" — resolves at reconcile time to the role the controller
 	//     is currently connected as (SELECT current_user). Use this when the
 	//     connection role differs per host (e.g. iam_creator, iam_creator_v2)
 	//     and hard-coding a role name is not viable. This is the recommended

--- a/config/crd/bases/postgresql.lunar.tech_customroles.yaml
+++ b/config/crd/bases/postgresql.lunar.tech_customroles.yaml
@@ -74,7 +74,7 @@ spec:
                     database owner, so SECURITY DEFINER\nruns with that role's privileges.
                     Set owningRole to override this (e.g. to\nuse a superuser role
                     for functions that need elevated privileges like ALTER ROLE).\nUse
-                    the sentinel value \"$controller\" to resolve to the controller's
+                    the sentinel value \"$controllerUser\" to resolve to the controller's
                     connection\nrole at reconcile time — recommended when the connection
                     role differs per host.\n\nExample:\n\n\tfunctions:\n\t- name:
                     my_function\n\t  args: \"input_val text\"\n\t  returns: void\n\t
@@ -103,7 +103,7 @@ spec:
                         If omitted, the function is owned by the database owner.
 
                         Special sentinel values:
-                          - "$controller" — resolves at reconcile time to the role the controller
+                          - "$controllerUser" — resolves at reconcile time to the role the controller
                             is currently connected as (SELECT current_user). Use this when the
                             connection role differs per host (e.g. iam_creator, iam_creator_v2)
                             and hard-coding a role name is not viable. This is the recommended

--- a/config/crd/bases/postgresql.lunar.tech_customroles.yaml
+++ b/config/crd/bases/postgresql.lunar.tech_customroles.yaml
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.name
+    - jsonPath: .spec.roleName
       name: Role
       type: string
     - jsonPath: .status.phase

--- a/config/crd/bases/postgresql.lunar.tech_customroles.yaml
+++ b/config/crd/bases/postgresql.lunar.tech_customroles.yaml
@@ -73,9 +73,12 @@ spec:
                     END automatically.\n\nBy default the function is owned by the
                     database owner, so SECURITY DEFINER\nruns with that role's privileges.
                     Set owningRole to override this (e.g. to\nuse a superuser role
-                    for functions that need elevated privileges like ALTER ROLE).\n\nExample:\n\n\tfunctions:\n\t-
-                    name: my_function\n\t  args: \"input_val text\"\n\t  returns:
-                    void\n\t  body: |\n\t    EXECUTE format('ALTER ROLE %I SET some_setting
+                    for functions that need elevated privileges like ALTER ROLE).\nUse
+                    the sentinel value \"$controller\" to resolve to the controller's
+                    connection\nrole at reconcile time — recommended when the connection
+                    role differs per host.\n\nExample:\n\n\tfunctions:\n\t- name:
+                    my_function\n\t  args: \"input_val text\"\n\t  returns: void\n\t
+                    \ body: |\n\t    EXECUTE format('ALTER ROLE %I SET some_setting
                     = %L', input_val, 'value');"
                   properties:
                     args:
@@ -98,6 +101,13 @@ spec:
                         OwningRole is the PostgreSQL role that will own the function. Since the
                         function uses SECURITY DEFINER, it executes with this role's privileges.
                         If omitted, the function is owned by the database owner.
+
+                        Special sentinel values:
+                          - "$controller" — resolves at reconcile time to the role the controller
+                            is currently connected as (SELECT current_user). Use this when the
+                            connection role differs per host (e.g. iam_creator, iam_creator_v2)
+                            and hard-coding a role name is not viable. This is the recommended
+                            value when the function must be owned by the controller's connection role.
                       type: string
                     returns:
                       description: Returns is the return type (e.g. "void", "boolean",

--- a/config/samples/postgresql_v1alpha1_customrole.yaml
+++ b/config/samples/postgresql_v1alpha1_customrole.yaml
@@ -3,6 +3,7 @@ kind: CustomRole
 metadata:
   name: reporting
 spec:
+  roleName: reporting
   grantRoles:
     - pg_monitor
   # Omit databases to apply grants and functions to every user database.
@@ -21,6 +22,8 @@ spec:
   # DEFINER runs with that role's privileges (least privilege).
   # Set owningRole to override this for functions that need elevated
   # privileges (e.g. ALTER ROLE requires a superuser-like role).
+  # Use $controllerUser as a sentinel to always resolve to the controller's
+  # own connection role.
   functions:
     # Owned by the database owner (default) — runs with its privileges.
     - name: my_query_function
@@ -34,14 +37,16 @@ kind: CustomRole
 metadata:
   name: admin-utils
 spec:
+  roleName: admin-utils
   # Restrict to the postgres database only.
   databases: [postgres]
   functions:
-    # owningRole overrides the default (database owner) so the function
-    # runs with iam_creator's privileges, which can ALTER ROLE.
+    # $controllerUser resolves to whatever role the controller is connected
+    # as — use this when the controller's admin role differs across hosts,
+    # e.g. iam_creator vs iam_creator_v2.
     - name: my_admin_function
       args: "target_role text"
       returns: void
-      owningRole: iam_creator
+      owningRole: $controllerUser
       body: |
         EXECUTE format('ALTER ROLE %I SET some_setting = %L', target_role, 'value');

--- a/pkg/postgres/customrole_functions.go
+++ b/pkg/postgres/customrole_functions.go
@@ -95,7 +95,7 @@ func randomDollarTag() string {
 // that resolves to the role the controller is currently connected as (SELECT current_user).
 // Use this when the connection role differs per host (e.g. iam_creator, iam_creator_v2)
 // and hard-coding a role name is not viable.
-const controllerSentinelOwningRole = "$controller"
+const controllerSentinelOwningRole = "$controllerUser"
 
 // currentUser returns the role name that the current connection is authenticated as.
 func currentUser(db *sql.DB) (string, error) {
@@ -204,7 +204,7 @@ func SyncDatabaseFunctions(log logr.Logger, db *sql.DB, roleName string, functio
 		}
 	}
 
-	// Resolve the controller sentinel once for functions that use $controller.
+	// Resolve the controller sentinel once for functions that use $controllerUser.
 	var controllerUser string
 	for _, f := range functions {
 		if f.OwningRole == controllerSentinelOwningRole {

--- a/pkg/postgres/customrole_functions.go
+++ b/pkg/postgres/customrole_functions.go
@@ -91,6 +91,21 @@ func randomDollarTag() string {
 	return "$f_" + hex.EncodeToString(b) + "$"
 }
 
+// controllerSentinelOwningRole is the sentinel value for CustomRoleFunction.OwningRole
+// that resolves to the role the controller is currently connected as (SELECT current_user).
+// Use this when the connection role differs per host (e.g. iam_creator, iam_creator_v2)
+// and hard-coding a role name is not viable.
+const controllerSentinelOwningRole = "$controller"
+
+// currentUser returns the role name that the current connection is authenticated as.
+func currentUser(db *sql.DB) (string, error) {
+	var user string
+	if err := db.QueryRow("SELECT current_user").Scan(&user); err != nil {
+		return "", fmt.Errorf("query current user: %w", err)
+	}
+	return user, nil
+}
+
 // managedFunctionPrefix returns the prefix used to name functions managed by
 // this role. The role name is used verbatim (including hyphens) so that two
 // roles whose names differ only by hyphen vs underscore (e.g. "reporting-db"
@@ -189,6 +204,19 @@ func SyncDatabaseFunctions(log logr.Logger, db *sql.DB, roleName string, functio
 		}
 	}
 
+	// Resolve the controller sentinel once for functions that use $controller.
+	var controllerUser string
+	for _, f := range functions {
+		if f.OwningRole == controllerSentinelOwningRole {
+			var err error
+			controllerUser, err = currentUser(db)
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+
 	// Build a map of currently-managed functions so we can detect ownership
 	// changes before attempting CREATE OR REPLACE.
 	current, err := managedFunctions(db, roleName)
@@ -208,8 +236,11 @@ func SyncDatabaseFunctions(log logr.Logger, db *sql.DB, roleName string, functio
 	desired := make(map[desiredFunctionKey]struct{})
 	for _, f := range functions {
 		owner := f.OwningRole
-		if owner == "" {
+		switch owner {
+		case "":
 			owner = dbOwner
+		case controllerSentinelOwningRole:
+			owner = controllerUser
 		}
 
 		pgName := managedFunctionName(roleName, f.Name)

--- a/pkg/postgres/customrole_functions_test.go
+++ b/pkg/postgres/customrole_functions_test.go
@@ -300,6 +300,116 @@ func TestSyncDatabaseFunctions_revokesPublicExecute(t *testing.T) {
 		"PUBLIC should not have EXECUTE on SECURITY DEFINER function")
 }
 
+// TestSyncDatabaseFunctions_controllerSentinelOwner verifies that owningRole: "$controller"
+// resolves to the current connection user and the created function is owned by that role.
+func TestSyncDatabaseFunctions_controllerSentinelOwner(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	pgName := fmt.Sprintf("custom_role_%d__myfunc", epoch)
+
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	err = postgres.SyncDatabaseFunctions(log, adminDB, roleName, []postgres.CustomRoleFunction{
+		{
+			Name:       "myfunc",
+			Returns:    "void",
+			Body:       "NULL;",
+			OwningRole: "$controller",
+		},
+	})
+	require.NoError(t, err)
+
+	require.True(t, functionExists(t, adminDB, "public", pgName), "function should exist")
+
+	// The function owner must equal the connection user (iam_creator).
+	var connUser string
+	require.NoError(t, adminDB.QueryRow("SELECT current_user").Scan(&connUser))
+	assert.Equal(t, connUser, functionOwner(t, adminDB, "public", pgName),
+		"function owner should equal current connection user")
+}
+
+// TestSyncDatabaseFunctions_controllerSentinelMixedOwners verifies that a CR can mix
+// "$controller" sentinel and literal role names in the same spec.
+func TestSyncDatabaseFunctions_controllerSentinelMixedOwners(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	pgNameCtrl := fmt.Sprintf("custom_role_%d__ctrl_func", epoch)
+	pgNameLit := fmt.Sprintf("custom_role_%d__lit_func", epoch)
+
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	// Get the db owner to use as the literal owner for the second function.
+	var dbOwner string
+	require.NoError(t, adminDB.QueryRow(`
+		SELECT r.rolname FROM pg_database d
+		JOIN pg_roles r ON r.oid = d.datdba
+		WHERE d.datname = current_database()`).Scan(&dbOwner))
+
+	err = postgres.SyncDatabaseFunctions(log, adminDB, roleName, []postgres.CustomRoleFunction{
+		{Name: "ctrl_func", Returns: "void", Body: "NULL;", OwningRole: "$controller"},
+		{Name: "lit_func", Returns: "void", Body: "NULL;", OwningRole: dbOwner},
+	})
+	require.NoError(t, err)
+
+	var connUser string
+	require.NoError(t, adminDB.QueryRow("SELECT current_user").Scan(&connUser))
+
+	assert.Equal(t, connUser, functionOwner(t, adminDB, "public", pgNameCtrl),
+		"ctrl_func owner should equal current connection user")
+	assert.Equal(t, dbOwner, functionOwner(t, adminDB, "public", pgNameLit),
+		"lit_func owner should equal the literal db owner role")
+}
+
+// TestSyncDatabaseFunctions_emptyOwningRoleFallsBackToDbOwner verifies that the existing
+// empty owningRole → database owner behavior is unchanged.
+func TestSyncDatabaseFunctions_emptyOwningRoleFallsBackToDbOwner(t *testing.T) {
+	host := test.Integration(t)
+	log := test.SetLogger(t)
+
+	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
+	})
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	epoch := time.Now().UnixNano()
+	roleName := fmt.Sprintf("custom_role_%d", epoch)
+	pgName := fmt.Sprintf("custom_role_%d__myfunc", epoch)
+
+	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
+
+	require.NoError(t, postgres.SyncDatabaseFunctions(log, adminDB, roleName, []postgres.CustomRoleFunction{
+		{Name: "myfunc", Returns: "void", Body: "NULL;"},
+	}))
+
+	var dbOwner string
+	require.NoError(t, adminDB.QueryRow(`
+		SELECT r.rolname FROM pg_database d
+		JOIN pg_roles r ON r.oid = d.datdba
+		WHERE d.datname = current_database()`).Scan(&dbOwner))
+
+	assert.Equal(t, dbOwner, functionOwner(t, adminDB, "public", pgName),
+		"function with empty owningRole should be owned by the database owner")
+}
+
 // functionExists returns true if a function with the given name exists in the schema.
 func functionExists(t *testing.T, db *sql.DB, schema, funcName string) bool {
 	t.Helper()
@@ -329,6 +439,20 @@ func functionExecuteGranted(t *testing.T, db *sql.DB, roleName, schema, funcName
 		)`, schema, funcName, roleName).Scan(&granted)
 	require.NoError(t, err)
 	return granted
+}
+
+// functionOwner returns the role name that owns the function.
+func functionOwner(t *testing.T, db *sql.DB, schema, funcName string) string {
+	t.Helper()
+	var owner string
+	err := db.QueryRow(`
+		SELECT r.rolname
+		FROM pg_proc p
+		JOIN pg_namespace n ON n.oid = p.pronamespace
+		JOIN pg_roles r ON r.oid = p.proowner
+		WHERE n.nspname = $1 AND p.proname = $2`, schema, funcName).Scan(&owner)
+	require.NoError(t, err)
+	return owner
 }
 
 // functionPublicExecuteGranted returns true if PUBLIC has EXECUTE on a function

--- a/pkg/postgres/customrole_functions_test.go
+++ b/pkg/postgres/customrole_functions_test.go
@@ -300,7 +300,7 @@ func TestSyncDatabaseFunctions_revokesPublicExecute(t *testing.T) {
 		"PUBLIC should not have EXECUTE on SECURITY DEFINER function")
 }
 
-// TestSyncDatabaseFunctions_controllerSentinelOwner verifies that owningRole: "$controller"
+// TestSyncDatabaseFunctions_controllerSentinelOwner verifies that owningRole: "$controllerUser"
 // resolves to the current connection user and the created function is owned by that role.
 func TestSyncDatabaseFunctions_controllerSentinelOwner(t *testing.T) {
 	host := test.Integration(t)
@@ -323,7 +323,7 @@ func TestSyncDatabaseFunctions_controllerSentinelOwner(t *testing.T) {
 			Name:       "myfunc",
 			Returns:    "void",
 			Body:       "NULL;",
-			OwningRole: "$controller",
+			OwningRole: "$controllerUser",
 		},
 	})
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestSyncDatabaseFunctions_controllerSentinelOwner(t *testing.T) {
 }
 
 // TestSyncDatabaseFunctions_controllerSentinelMixedOwners verifies that a CR can mix
-// "$controller" sentinel and literal role names in the same spec.
+// "$controllerUser" sentinel and literal role names in the same spec.
 func TestSyncDatabaseFunctions_controllerSentinelMixedOwners(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
@@ -364,7 +364,7 @@ func TestSyncDatabaseFunctions_controllerSentinelMixedOwners(t *testing.T) {
 		WHERE d.datname = current_database()`).Scan(&dbOwner))
 
 	err = postgres.SyncDatabaseFunctions(log, adminDB, roleName, []postgres.CustomRoleFunction{
-		{Name: "ctrl_func", Returns: "void", Body: "NULL;", OwningRole: "$controller"},
+		{Name: "ctrl_func", Returns: "void", Body: "NULL;", OwningRole: "$controllerUser"},
 		{Name: "lit_func", Returns: "void", Body: "NULL;", OwningRole: dbOwner},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Introduces the `$controllerUser` sentinel value for `spec.functions[*].owningRole` in `CustomRole` resources.
- When a function's `owningRole` is set to `$controllerUser`, the controller resolves it at reconcile time to `SELECT current_user` — the role the controller is currently connected as — and sets that role as the SECURITY DEFINER function's owner.
- Renames the previously introduced sentinel from `$controller` → `$controllerUser` for clarity (the name now mirrors the `current_user` SQL function it resolves to).

## Motivation

RDS blocks `SET ROLE rds_superuser` from non-master users even when `pg_auth_members.set_option = true`. The controller must therefore own SECURITY DEFINER functions itself (e.g. functions that call `ALTER ROLE`) rather than transferring ownership to a superuser role.

The admin role the controller connects as is not uniform across hosts:

| Environment  | Connection role      |
|---|---|
| Staging      | `iam_creator`        |
| Production A | `iam_creator_v2`     |
| Production B | `iam_creator_new`    |

Hard-coding a literal role name in the `CustomRole` spec would break on every other host. The `$controllerUser` sentinel lets users write a single spec that works everywhere: the controller substitutes its own connection identity at reconcile time.

## Changes

- `pkg/postgres/customrole_functions.go`: constant value `"$controller"` → `"$controllerUser"`; comment updated.
- `api/v1alpha1/customrole_types.go`: godoc on `CustomRoleFunction` and `OwningRole` updated.
- `config/crd/bases/postgresql.lunar.tech_customroles.yaml`: regenerated via `make manifests`.
- `pkg/postgres/customrole_functions_test.go`: test literals updated.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `go fmt ./...` — no changes
- [x] `POSTGRESQL_CONTROLLER_INTEGRATION_HOST=localhost:5432 go test ./pkg/postgres/... -timeout 120s` — passes (including `TestSyncDatabaseFunctions_controllerSentinelOwner` and `TestSyncDatabaseFunctions_controllerSentinelMixedOwners`)
- [ ] Deploy to staging and verify a `CustomRole` with `owningRole: $controllerUser` creates a SECURITY DEFINER function owned by `iam_creator`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes how SECURITY DEFINER function ownership is determined during reconciliation, which can affect privilege boundaries and function lifecycle (drop/recreate) across databases.
> 
> **Overview**
> Adds support for a special `owningRole: $controllerUser` value on `CustomRole` SECURITY DEFINER functions, resolving it at reconcile time to `SELECT current_user` so functions can be owned by the controller’s actual connection role (useful when admin roles differ per host/RDS). 
> 
> Updates CRD/docs/samples accordingly, adjusts the `kubectl` printer column to show `.spec.roleName`, and adds integration tests covering sentinel resolution, mixing sentinel + literal owners, and preserving the default empty `owningRole` → database owner behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523e064fb0ec3e3d2f7317f5743f68f43e4d596c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->