### PR TITLE
Add failingHost to CustomRole status, drop noisy connect log

### DIFF
--- a/api/v1alpha1/customrole_types.go
+++ b/api/v1alpha1/customrole_types.go
@@ -158,6 +158,11 @@ type CustomRoleStatus struct {
 	// Error contains the error message when Phase is Failed or Invalid
 	// +optional
 	Error string `json:"error,omitempty"`
+
+	// FailingHost is the PostgreSQL host that caused reconciliation to fail.
+	// Empty when reconciliation succeeded or the failure is not host-specific.
+	// +optional
+	FailingHost string `json:"failingHost,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/customrole_types.go
+++ b/api/v1alpha1/customrole_types.go
@@ -189,6 +189,10 @@ type CustomRoleList struct {
 	Items           []CustomRole `json:"items"`
 }
 
+func (s CustomRoleStatus) IsUnchanged(phase CustomRolePhase, errorMessage, failingHost string) bool {
+	return s.Phase == phase && s.Error == errorMessage && s.FailingHost == failingHost
+}
+
 func init() {
 	SchemeBuilder.Register(&CustomRole{}, &CustomRoleList{})
 }

--- a/config/crd/bases/postgresql.lunar.tech_customroles.yaml
+++ b/config/crd/bases/postgresql.lunar.tech_customroles.yaml
@@ -178,6 +178,11 @@ spec:
                 description: Error contains the error message when Phase is Failed
                   or Invalid
                 type: string
+              failingHost:
+                description: |-
+                  FailingHost is the PostgreSQL host that caused reconciliation to fail.
+                  Empty when reconciliation succeeded or the failure is not host-specific.
+                type: string
               phase:
                 description: Phase is the current phase of the CustomRole resource
                 type: string

--- a/internal/controller/customrole_controller.go
+++ b/internal/controller/customrole_controller.go
@@ -247,6 +247,7 @@ func (r *CustomRoleReconciler) persistStatus(ctx context.Context, customRole *po
 	case ctlerrors.IsInvalid(reconcileErr):
 		phase = postgresqlv1alpha1.CustomRolePhaseInvalid
 		errorMessage = reconcileErr.Error()
+		failingHost = ""
 	default:
 		phase = postgresqlv1alpha1.CustomRolePhaseFailed
 		errorMessage = reconcileErr.Error()

--- a/internal/controller/customrole_controller.go
+++ b/internal/controller/customrole_controller.go
@@ -166,12 +166,12 @@ func (r *CustomRoleReconciler) reconcile(ctx context.Context, reqLogger logr.Log
 
 	for host, creds := range r.HostCredentials {
 		if err := r.reconcileOnHost(reqLogger, host, creds, roleName, customRole.Spec.GrantRoles, customRole.Spec.Databases, grants, functions); err != nil {
-			r.persistStatus(ctx, customRole, err)
+			r.persistStatus(ctx, customRole, host, err)
 			return fmt.Errorf("reconcile on host %s: %w", host, err)
 		}
 	}
 
-	r.persistStatus(ctx, customRole, nil)
+	r.persistStatus(ctx, customRole, "", nil)
 	return nil
 }
 
@@ -236,13 +236,14 @@ func resolveTargetDatabases(log logr.Logger, adminDB *sql.DB, targetDatabases []
 	return databases, nil, nil
 }
 
-func (r *CustomRoleReconciler) persistStatus(ctx context.Context, customRole *postgresqlv1alpha1.CustomRole, reconcileErr error) {
+func (r *CustomRoleReconciler) persistStatus(ctx context.Context, customRole *postgresqlv1alpha1.CustomRole, failingHost string, reconcileErr error) {
 	var phase postgresqlv1alpha1.CustomRolePhase
 	var errorMessage string
 
 	switch {
 	case reconcileErr == nil:
 		phase = postgresqlv1alpha1.CustomRolePhaseRunning
+		failingHost = ""
 	case ctlerrors.IsInvalid(reconcileErr):
 		phase = postgresqlv1alpha1.CustomRolePhaseInvalid
 		errorMessage = reconcileErr.Error()
@@ -251,13 +252,16 @@ func (r *CustomRoleReconciler) persistStatus(ctx context.Context, customRole *po
 		errorMessage = reconcileErr.Error()
 	}
 
-	if customRole.Status.Phase == phase && customRole.Status.Error == errorMessage {
+	if customRole.Status.Phase == phase &&
+		customRole.Status.Error == errorMessage &&
+		customRole.Status.FailingHost == failingHost {
 		return
 	}
 
 	customRole.Status.Phase = phase
 	customRole.Status.PhaseUpdated = metav1.Now()
 	customRole.Status.Error = errorMessage
+	customRole.Status.FailingHost = failingHost
 
 	if err := r.Client.Status().Update(ctx, customRole); err != nil {
 		r.Log.Error(err, "failed to update CustomRole status")

--- a/internal/controller/customrole_controller.go
+++ b/internal/controller/customrole_controller.go
@@ -185,7 +185,7 @@ func (r *CustomRoleReconciler) reconcileOnHost(log logr.Logger, host string, cre
 		Password: creds.Password,
 		Params:   creds.Params,
 	}
-	adminDB, err := postgres.Connect(log, adminConnStr)
+	adminDB, err := postgres.Connect(adminConnStr)
 	if err != nil {
 		return fmt.Errorf("connect to host: %w", err)
 	}
@@ -252,9 +252,7 @@ func (r *CustomRoleReconciler) persistStatus(ctx context.Context, customRole *po
 		errorMessage = reconcileErr.Error()
 	}
 
-	if customRole.Status.Phase == phase &&
-		customRole.Status.Error == errorMessage &&
-		customRole.Status.FailingHost == failingHost {
+	if customRole.Status.IsUnchanged(phase, errorMessage, failingHost) {
 		return
 	}
 

--- a/internal/controller/customrole_functions.go
+++ b/internal/controller/customrole_functions.go
@@ -71,7 +71,7 @@ func (r *CustomRoleReconciler) syncFunctionsOnDatabase(log logr.Logger, host str
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}
-	db, err := postgres.Connect(log, connStr)
+	db, err := postgres.Connect(connStr)
 	if err != nil {
 		return fmt.Errorf("connect to %s: %w", connStr, err)
 	}

--- a/internal/controller/customrole_grants.go
+++ b/internal/controller/customrole_grants.go
@@ -53,7 +53,7 @@ func (r *CustomRoleReconciler) syncGrantsOnDatabase(log logr.Logger, host string
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}
-	db, err := postgres.Connect(log, connStr)
+	db, err := postgres.Connect(connStr)
 	if err != nil {
 		return fmt.Errorf("connect to %s: %w", connStr, err)
 	}

--- a/internal/controller/customrole_roles.go
+++ b/internal/controller/customrole_roles.go
@@ -34,7 +34,7 @@ func (r *CustomRoleReconciler) cleanupRoleOnHost(log logr.Logger, host string, c
 		Password: creds.Password,
 		Params:   creds.Params,
 	}
-	adminDB, err := postgres.Connect(log, adminConnStr)
+	adminDB, err := postgres.Connect(adminConnStr)
 	if err != nil {
 		return fmt.Errorf("connect to host: %w", err)
 	}
@@ -52,7 +52,7 @@ func (r *CustomRoleReconciler) cleanupRoleOnHost(log logr.Logger, host string, c
 			Password: creds.Password,
 			Params:   creds.Params,
 		}
-		db, err := postgres.Connect(log, connStr)
+		db, err := postgres.Connect(connStr)
 		if err != nil {
 			return fmt.Errorf("connect to %s: %w", dbName, err)
 		}

--- a/internal/controller/postgresqluser_controller_test.go
+++ b/internal/controller/postgresqluser_controller_test.go
@@ -564,7 +564,7 @@ func TestReconcile_multipleDatabaseResources(t *testing.T) {
 func seededDatabase(t *testing.T, host, databaseName, userName string, managerRole string) {
 	t.Helper()
 
-	dbConn, err := postgres.Connect(logf.Log, postgres.ConnectionString{
+	dbConn, err := postgres.Connect(postgres.ConnectionString{
 		Database: "postgres",
 		Host:     host,
 		Password: "iam_creator",
@@ -586,7 +586,7 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 	}, managerRole, nil)
 	require.NoErrorf(t, err, "failed to created seeded database '%s'", databaseName)
 
-	db1Conn, err := postgres.Connect(logf.Log, postgres.ConnectionString{
+	db1Conn, err := postgres.Connect(postgres.ConnectionString{
 		Database: databaseName,
 		Host:     host,
 		Password: databaseName,
@@ -599,7 +599,7 @@ func seededDatabase(t *testing.T, host, databaseName, userName string, managerRo
 }
 
 func assertAccess(t *testing.T, host, databaseName, userName string) {
-	userConn, err := postgres.Connect(logf.Log, postgres.ConnectionString{
+	userConn, err := postgres.Connect(postgres.ConnectionString{
 		Database: databaseName,
 		Host:     host,
 		User:     userName,

--- a/pkg/grants/sync.go
+++ b/pkg/grants/sync.go
@@ -73,7 +73,7 @@ func (g *Granter) connectToHosts(log logr.Logger, accesses HostAccess) (map[stri
 			User:     credentials.User,
 			Password: credentials.Password,
 		}
-		db, err := postgres.Connect(log, connectionString)
+		db, err := postgres.Connect(connectionString)
 		if err != nil {
 			errs = multierr.Append(errs, fmt.Errorf("connect to %s: %w", connectionString, err))
 			continue

--- a/pkg/postgres/customrole_functions_test.go
+++ b/pkg/postgres/customrole_functions_test.go
@@ -16,7 +16,7 @@ func TestSyncDatabaseFunctions_rejectsNameWithDoubleUnderscore(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestSyncDatabaseFunctions_createsFunction(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -68,7 +68,7 @@ func TestSyncDatabaseFunctions_idempotent(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestSyncDatabaseFunctions_dropsRemovedFunction(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestSyncDatabaseFunctions_dropsAllWhenEmpty(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestDropManagedFunctions(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestSyncDatabaseFunctions_doesNotDropFunctionsOfLongerPrefixRole(t *testing
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestDropManagedFunctions_doesNotDropFunctionsOfLongerPrefixRole(t *testing.
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestSyncDatabaseFunctions_securityDefiner(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -278,7 +278,7 @@ func TestSyncDatabaseFunctions_revokesPublicExecute(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestSyncDatabaseFunctions_controllerSentinelOwner(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -343,7 +343,7 @@ func TestSyncDatabaseFunctions_controllerSentinelMixedOwners(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -384,7 +384,7 @@ func TestSyncDatabaseFunctions_emptyOwningRoleFallsBackToDbOwner(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)

--- a/pkg/postgres/customrole_grants_test.go
+++ b/pkg/postgres/customrole_grants_test.go
@@ -16,7 +16,7 @@ func TestApplyDatabaseGrants_specificSchemaAllTables(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -39,7 +39,7 @@ func TestApplyDatabaseGrants_specificSchemaAllTables(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -66,7 +66,7 @@ func TestApplyDatabaseGrants_specificTable(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -89,7 +89,7 @@ func TestApplyDatabaseGrants_specificTable(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -117,7 +117,7 @@ func TestApplyDatabaseGrants_allSchemasAllTables(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -140,7 +140,7 @@ func TestApplyDatabaseGrants_allSchemasAllTables(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -170,7 +170,7 @@ func TestApplyDatabaseGrants_idempotent(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -192,7 +192,7 @@ func TestApplyDatabaseGrants_idempotent(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -215,7 +215,7 @@ func TestSyncDatabaseGrants_grantCombinations(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -239,7 +239,7 @@ func TestSyncDatabaseGrants_grantCombinations(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -441,7 +441,7 @@ func TestSyncDatabaseGrants_revokesRemovedPrivilege(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -463,7 +463,7 @@ func TestSyncDatabaseGrants_revokesRemovedPrivilege(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -496,7 +496,7 @@ func TestSyncDatabaseGrants_revokesRemovedGrant(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -518,7 +518,7 @@ func TestSyncDatabaseGrants_revokesRemovedGrant(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: dbName,
 		User:     "iam_creator",
@@ -548,7 +548,7 @@ func TestSyncDatabaseGrants_partialRevokePreservesSchemaUsage(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -571,7 +571,7 @@ func TestSyncDatabaseGrants_partialRevokePreservesSchemaUsage(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -603,7 +603,7 @@ func TestSyncDatabaseGrants_picksUpNewTable(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -626,7 +626,7 @@ func TestSyncDatabaseGrants_picksUpNewTable(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -658,7 +658,7 @@ func TestSyncDatabaseGrants_skipsMissingSchemaAndTable(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -680,7 +680,7 @@ func TestSyncDatabaseGrants_skipsMissingSchemaAndTable(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -726,7 +726,7 @@ func TestSyncDatabaseGrants_omittedSchemaAndTable_dbNamedSchema(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -745,7 +745,7 @@ func TestSyncDatabaseGrants_omittedSchemaAndTable_dbNamedSchema(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -784,7 +784,7 @@ func TestSyncDatabaseGrants_skipsPermissionDenied(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -807,7 +807,7 @@ func TestSyncDatabaseGrants_skipsPermissionDenied(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -830,7 +830,7 @@ func TestSyncDatabaseGrants_skipsPermissionDenied(t *testing.T) {
 	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
 
 	// Connect as the controller — it owns the schema and one table but not the other.
-	controllerDB, err := postgres.Connect(log, postgres.ConnectionString{
+	controllerDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: controllerUser, Password: controllerUser,
 	})
 	require.NoError(t, err)
@@ -861,7 +861,7 @@ func TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -884,7 +884,7 @@ func TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -904,7 +904,7 @@ func TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner(t *testing.T) {
 
 	// Create schema and tables owned by the service user.
 	dbExec(t, targetDB, fmt.Sprintf("CREATE SCHEMA %s AUTHORIZATION %s", schemaName, serviceUser))
-	serviceDB, err := postgres.Connect(log, postgres.ConnectionString{
+	serviceDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: serviceUser, Password: serviceUser,
 	})
 	require.NoError(t, err)
@@ -923,7 +923,7 @@ func TestSyncDatabaseGrants_grantsViaSetRoleToTableOwner(t *testing.T) {
 	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
 
 	// Connect as the controller user (member of service user, but not the table owner).
-	controllerDB, err := postgres.Connect(log, postgres.ConnectionString{
+	controllerDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: controllerUser, Password: controllerUser,
 	})
 	require.NoError(t, err)
@@ -962,7 +962,7 @@ func TestRevokeAllDatabaseGrants_viaSetRole(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: "postgres", User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -983,7 +983,7 @@ func TestRevokeAllDatabaseGrants_viaSetRole(t *testing.T) {
 		"postgres_role_name", nil,
 	))
 
-	targetDB, err := postgres.Connect(log, postgres.ConnectionString{
+	targetDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: "iam_creator", Password: "iam_creator",
 	})
 	require.NoError(t, err)
@@ -998,7 +998,7 @@ func TestRevokeAllDatabaseGrants_viaSetRole(t *testing.T) {
 
 	// Create schema and table owned by the service user.
 	dbExec(t, targetDB, fmt.Sprintf("CREATE SCHEMA %s AUTHORIZATION %s", schemaName, serviceUser))
-	serviceDB, err := postgres.Connect(log, postgres.ConnectionString{
+	serviceDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: serviceUser, Password: serviceUser,
 	})
 	require.NoError(t, err)
@@ -1008,7 +1008,7 @@ func TestRevokeAllDatabaseGrants_viaSetRole(t *testing.T) {
 	// Create custom role and grant privileges via SET ROLE.
 	require.NoError(t, postgres.EnsureCustomRole(log, adminDB, roleName, nil))
 
-	controllerDB, err := postgres.Connect(log, postgres.ConnectionString{
+	controllerDB, err := postgres.Connect(postgres.ConnectionString{
 		Host: host, Database: dbName, User: controllerUser, Password: controllerUser,
 	})
 	require.NoError(t, err)

--- a/pkg/postgres/customrole_roles_test.go
+++ b/pkg/postgres/customrole_roles_test.go
@@ -16,7 +16,7 @@ func TestEnsureCustomRole_createsRole(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -38,7 +38,7 @@ func TestEnsureCustomRole_idempotent(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -57,7 +57,7 @@ func TestEnsureCustomRole_grantsRoles(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -79,7 +79,7 @@ func TestEnsureCustomRole_revokesRemovedRole(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",

--- a/pkg/postgres/customrole_test.go
+++ b/pkg/postgres/customrole_test.go
@@ -15,7 +15,7 @@ func TestUserDatabases(t *testing.T) {
 	host := test.Integration(t)
 	log := test.SetLogger(t)
 
-	adminDB, err := postgres.Connect(log, postgres.ConnectionString{
+	adminDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "iam_creator",

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -79,7 +79,7 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}
-	serviceConnection, err := Connect(log, serviceConnectionString)
+	serviceConnection, err := Connect(serviceConnectionString)
 	if err != nil {
 		return fmt.Errorf("connect to host %s: %w", serviceConnectionString, err)
 	}
@@ -217,7 +217,7 @@ func createDatabase(log logr.Logger, host string, adminCredentials Credentials, 
 		Password: adminCredentials.Password,
 		Params:   adminCredentials.Params,
 	}
-	db, err := Connect(log, connectionString)
+	db, err := Connect(connectionString)
 	if err != nil {
 		return fmt.Errorf("connect to host %s: %w", connectionString, err)
 	}

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -81,7 +81,7 @@ func TestDatabase_sunshine(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 	managerRole := "postgres_role_name"
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -115,7 +115,7 @@ func TestDatabase_sunshine(t *testing.T) {
 	assert.True(t, roleCanLogin(t, db, name))
 	assert.True(t, hasPassword(t, log, postgresqlHost, name))
 
-	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+	newDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     name,
@@ -144,7 +144,7 @@ func TestDatabase_HasExtensionsNotExistingAlreadyEnableExtensions(t *testing.T) 
 	log := test.SetLogger(t)
 
 	managerRole := "postgres_role_name"
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -179,7 +179,7 @@ func TestDatabase_HasExtensionsNotExistingAlreadyEnableExtensions(t *testing.T) 
 	assert.True(t, roleCanLogin(t, db, name))
 	assert.True(t, hasPassword(t, log, postgresqlHost, name))
 
-	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+	newDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     name,
@@ -203,7 +203,7 @@ func TestDatabase_HasExtensionsNoUpdates(t *testing.T) {
 	log := test.SetLogger(t)
 
 	managerRole := "postgres_role_name"
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -244,7 +244,7 @@ func TestDatabase_HasExtensionsNoUpdates(t *testing.T) {
 	assert.True(t, roleCanLogin(t, db, name))
 	assert.True(t, hasPassword(t, log, postgresqlHost, name))
 
-	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+	newDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     name,
@@ -295,7 +295,7 @@ func TestDatabase_HasExtensionsGiveEmptyDeclarativeExtensionsShouldDoNothing(t *
 	log := test.SetLogger(t)
 
 	managerRole := "postgres_role_name"
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -336,7 +336,7 @@ func TestDatabase_HasExtensionsGiveEmptyDeclarativeExtensionsShouldDoNothing(t *
 	assert.True(t, roleCanLogin(t, db, name))
 	assert.True(t, hasPassword(t, log, postgresqlHost, name))
 
-	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+	newDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     name,
@@ -386,7 +386,7 @@ func TestDatabase_noPassword(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 	managerRole := "postgres_role_name"
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -417,7 +417,7 @@ func TestDatabase_noPassword(t *testing.T) {
 
 	assert.False(t, roleCanLogin(t, db, name))
 
-	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+	newDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     "iam_creator",
@@ -446,7 +446,7 @@ func TestDatabase_switchFromLoginToNoLoginAndBack(t *testing.T) {
 	log := test.SetLogger(t)
 	managerRole := "postgres_role_name"
 
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -511,7 +511,7 @@ func TestDatabase_switchFromLoginToNoLoginAndBack(t *testing.T) {
 	assert.True(t, roleCanLogin(t, db, name))
 	assert.True(t, hasPassword(t, log, postgresqlHost, name))
 
-	newDB, err := postgres.Connect(log, postgres.ConnectionString{
+	newDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     "iam_creator",
@@ -546,7 +546,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	log := test.SetLogger(t)
 	managerRole := "postgres_role_name"
 	log.Info("TC: Connection as iam_creator")
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -573,7 +573,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	`, name))
 
 	log.Info("TC: Connect as service user")
-	serviceDB, err := postgres.Connect(log, postgres.ConnectionString{
+	serviceDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     name,
@@ -615,7 +615,7 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	}
 
 	log.Info("TC: Connect as developer")
-	developerDB, err := postgres.Connect(log, postgres.ConnectionString{
+	developerDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: name,
 		User:     developerName,
@@ -639,7 +639,7 @@ func TestDatabase_defaultDatabaseName(t *testing.T) {
 	managerRole := "postgres_role_name"
 	log := test.SetLogger(t)
 	log.Info("TC: Connecting as iam_creator")
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -698,7 +698,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.NewLogger(t)
 	log.Info("TC: Connecting as iam_creator on defaul database")
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -731,7 +731,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	dbExec(t, db, `REVOKE %s FROM CURRENT_USER`, sharedDatabaseName)
 
 	// connect to shared database with created role
-	sharedConn, err := postgres.Connect(log, postgres.ConnectionString{
+	sharedConn, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: sharedDatabaseName,
 		User:     sharedDatabaseName,
@@ -774,7 +774,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 
 	// connect as the new user and do some queries to ensure permissions are
 	// correct
-	newUserConn, err := postgres.Connect(log, postgres.ConnectionString{
+	newUserConn, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: sharedDatabaseName,
 		User:     newUser,
@@ -813,7 +813,7 @@ func TestDatabase_mixedOwnershipOnSharedDatabase(t *testing.T) {
 	}
 
 	// connect as the developer on the shared database
-	developerConn, err := postgres.Connect(log, postgres.ConnectionString{
+	developerConn, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: sharedDatabaseName,
 		User:     developer,
@@ -837,7 +837,7 @@ func TestDatabase_idempotency(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 	managerRole := "postgres_role_name"
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		Database: "postgres",
 		User:     "iam_creator",
@@ -884,7 +884,7 @@ func TestDatabase_idempotency(t *testing.T) {
 }
 
 func hasPassword(t *testing.T, log logr.Logger, host, username string) bool {
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		Database: "postgres",
 		User:     "admin",

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -49,7 +49,7 @@ func (c ConnectionString) String() string {
 	return strings.ReplaceAll(raw, url.QueryEscape(c.Password), "********")
 }
 
-func Connect(log logr.Logger, connectionString ConnectionString) (*sql.DB, error) {
+func Connect(connectionString ConnectionString) (*sql.DB, error) {
 	db, err := sql.Open("postgres", connectionString.Raw())
 	if err != nil {
 		return nil, err

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -50,7 +50,6 @@ func (c ConnectionString) String() string {
 }
 
 func Connect(log logr.Logger, connectionString ConnectionString) (*sql.DB, error) {
-	log.Info("Connecting to database", "url", connectionString)
 	db, err := sql.Open("postgres", connectionString.Raw())
 	if err != nil {
 		return nil, err

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -149,7 +149,7 @@ func TestConnect_idleConnections(t *testing.T) {
 	// the connection pool is properly configured the idle connections will be
 	// dropped before we call Close.
 	for i := 0; i < 100; i++ {
-		conn, err := postgres.Connect(logger, connectionString)
+		conn, err := postgres.Connect(connectionString)
 		if err != nil {
 			t.Fatalf("connect to database failed: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestConnect_idleConnections(t *testing.T) {
 func TestRole_staticRoles(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
-	db, err := postgres.Connect(log, postgres.ConnectionString{
+	db, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: "postgres",
@@ -262,7 +262,7 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 
-	iamCreatorRootDB, err := postgres.Connect(log, postgres.ConnectionString{
+	iamCreatorRootDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: "postgres",
@@ -291,7 +291,7 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 	//
 
 	// reconnect to start a new session with grants from above database creation
-	iamCreatorUserDB, err := postgres.Connect(log, postgres.ConnectionString{
+	iamCreatorUserDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: serviceUser1,
@@ -312,7 +312,7 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 		return
 	}
 
-	userDB, err := postgres.Connect(log, postgres.ConnectionString{
+	userDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     developerUser,
 		Database: serviceUser1,
@@ -333,7 +333,7 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 
 	// ensure we revoke the privilege again
 
-	iamCreatorUserDB, err = postgres.Connect(log, postgres.ConnectionString{
+	iamCreatorUserDB, err = postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: serviceUser1,
@@ -354,7 +354,7 @@ func TestRole_owningWritePriviliges(t *testing.T) {
 		return
 	}
 
-	userDB, err = postgres.Connect(log, postgres.ConnectionString{
+	userDB, err = postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     developerUser,
 		Database: serviceUser1,
@@ -378,7 +378,7 @@ func TestRole_priviliges(t *testing.T) {
 	postgresqlHost := test.Integration(t)
 	log := test.SetLogger(t)
 
-	iamCreatorRootDB, err := postgres.Connect(log, postgres.ConnectionString{
+	iamCreatorRootDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: "postgres",
@@ -410,7 +410,7 @@ func TestRole_priviliges(t *testing.T) {
 	//
 
 	// reconnect to start a new session with grants from above database creation
-	iamCreatorUserDB, err := postgres.Connect(log, postgres.ConnectionString{
+	iamCreatorUserDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: serviceUser1,
@@ -431,7 +431,7 @@ func TestRole_priviliges(t *testing.T) {
 		return
 	}
 
-	userDB, err := postgres.Connect(log, postgres.ConnectionString{
+	userDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     developerUser,
 		Database: serviceUser1,
@@ -456,7 +456,7 @@ func TestRole_priviliges(t *testing.T) {
 	//
 
 	// reconnect to start a new session with grants from above database creation
-	iamCreatorUserDB, err = postgres.Connect(log, postgres.ConnectionString{
+	iamCreatorUserDB, err = postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",
 		Database: serviceUser2,
@@ -482,7 +482,7 @@ func TestRole_priviliges(t *testing.T) {
 		return
 	}
 
-	userDB, err = postgres.Connect(log, postgres.ConnectionString{
+	userDB, err = postgres.Connect(postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     developerUser,
 		Database: serviceUser2,
@@ -518,7 +518,7 @@ func createServiceDatabase(t *testing.T, log logr.Logger, host, service string) 
 		t.Fatalf("Failed to create database: %v", err)
 	}
 
-	serviceUserDB, err := postgres.Connect(log, postgres.ConnectionString{
+	serviceUserDB, err := postgres.Connect(postgres.ConnectionString{
 		Host:     host,
 		User:     service,
 		Database: service,

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -136,7 +136,6 @@ func TestConnectionString_logger(t *testing.T) {
 // each connection and don't let the sql.DB connection pool keep them open.
 func TestConnect_idleConnections(t *testing.T) {
 	postgresqlHost := test.Integration(t)
-	logger := test.NewLogger(t)
 	connectionString := postgres.ConnectionString{
 		Host:     postgresqlHost,
 		User:     "iam_creator",


### PR DESCRIPTION
## Summary
- Add `status.failingHost` to `CustomRole` so operators can see which PostgreSQL host caused a reconcile failure without grepping controller logs.
- Remove the `Connecting to database` log line in `pkg/postgres/postgres.go`. It fired on every connect — admin DB plus per-database connections for grants and functions — so each resync cycle produced many lines per CustomRole.

## Notes
- `persistStatus` now takes the failing host and clears it on success.
- CRD and deepcopy regenerated via `make generate manifests`.
- Existing CustomRoles already in `Failed` won't get `failingHost` populated until they next reconcile.

## Test plan
- [ ] Apply the updated CRD; existing CustomRoles still validate.
- [ ] Trigger a reconcile failure on one host (e.g. wrong credentials) and confirm `status.failingHost` reports it and `status.error` matches.
- [ ] Resolve the failure and confirm `status.failingHost` clears on the next successful reconcile.
- [ ] Confirm controller logs no longer emit `Connecting to database`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it updates the `CustomRole` CRD/status schema and refactors the widely-used `postgres.Connect` API, which could affect controller behavior and diagnostics if any call sites were missed.
> 
> **Overview**
> Adds `status.failingHost` to `CustomRole` and updates reconciliation to persist the host that triggered a failure (and clear it on success/invalid), including an `IsUnchanged` helper to avoid no-op status updates.
> 
> Removes the per-connection "Connecting to database" log by changing `postgres.Connect` to no longer accept a logger, then updates all controller code and tests to use the new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d12464988de719d2e281d83b1e368548f1b9d20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->