### PR TITLE
chore: transfer ownership to squad-dark-matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-esa
+* @lunarway/squad-dark-matter


### PR DESCRIPTION
Transfers repo ownership from squad-esa to squad-dark-matter as part of DMAT-12.

- CODEOWNERS: `* @lunarway/squad-dark-matter`

Linear: [DMAT-12](https://linear.app/lunar/issue/DMAT-12/database-as-a-service)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only repository ownership metadata via `CODEOWNERS`, with no impact on runtime behavior or data handling.
> 
> **Overview**
> **Ownership update:** Changes `CODEOWNERS` so all paths (`*`) are now owned by `@lunarway/squad-dark-matter` instead of the previous squad.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4efd9fa9ca4ca6f11b9624c1bcf25f645124fd8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->