### PR TITLE
feat: add global database extensions flag to controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,7 @@ func main() {
 		ManagerRoleName:   config.ManagerRoleName,
 		SuperuserRoleName: config.SuperuserRoleName,
 		HostCredentials:   config.HostCredentials,
+		GlobalExtensions:  config.GetGlobalExtensions(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PostgreSQLDatabase")
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,23 +14,23 @@ import (
 )
 
 type ControllerConfiguration struct {
-	MetricsAddress           string
-	ProbeAddress             string
-	EnableLeaderElection     bool
-	ResyncPeriod             time.Duration
-	UserRoles                string
-	UserRolePrefix           string
-	GlobalExtensions         string
-	AWS                      AwsConfig
-	HostCredentials          map[string]postgres.Credentials
-	ManagerRoleName          string
-	SuperuserRoleName        string
-	AllDatabasesReadEnabled  bool
-	AllDatabasesWriteEnabled bool
-	ExtendedWriteEnabled     bool
-	IAMPolicyPrefix          string
-	SecureMetrics            bool
-	EnableHTTP2              bool
+	MetricsAddress            string
+	ProbeAddress              string
+	EnableLeaderElection      bool
+	ResyncPeriod              time.Duration
+	UserRoles                 string
+	UserRolePrefix            string
+	GlobalExtensionsToInstall string
+	AWS                       AwsConfig
+	HostCredentials           map[string]postgres.Credentials
+	ManagerRoleName           string
+	SuperuserRoleName         string
+	AllDatabasesReadEnabled   bool
+	AllDatabasesWriteEnabled  bool
+	ExtendedWriteEnabled      bool
+	IAMPolicyPrefix           string
+	SecureMetrics             bool
+	EnableHTTP2               bool
 }
 
 type AwsConfig struct {
@@ -55,7 +55,7 @@ func (c *ControllerConfiguration) RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&c.ManagerRoleName, "manager-role-name", "postgres_role_manager", "Name of the role which will be managing other roles")
 	flagSet.StringVar(&c.SuperuserRoleName, "superuser-role-name", "rds_superuser", "Name of the superuser role the connecting user must be a member of (defaults to RDS's rds_superuser; override for non-RDS deployments)")
 	flagSet.StringVar(&c.UserRoles, "user-roles", "rds_iam", "List of roles granted to all users")
-	flagSet.StringVar(&c.GlobalExtensions, "global-extensions", "", "Comma-separated list of PostgreSQL extensions to install on all databases")
+	flagSet.StringVar(&c.GlobalExtensionsToInstall, "global-extensions-to-install", "", "Comma-separated list of PostgreSQL extensions to install on all databases (existing extensions are never removed)")
 	flagSet.BoolVar(&c.AllDatabasesReadEnabled, "all-databases-enabled-read", false, "Enable usage of allDatabases field in read access requests")
 	flagSet.BoolVar(&c.AllDatabasesWriteEnabled, "all-databases-enabled-write", false, "Enable usage of allDatabases field in write access requests")
 	flagSet.StringVar(&c.UserRolePrefix, "user-role-prefix", "iam_developer_", "Prefix of roles created in PostgreSQL for users")
@@ -81,20 +81,36 @@ func (c *ControllerConfiguration) GetLoginRoles() []string {
 }
 
 // GetGlobalExtensions returns the list of global extensions to install on all databases.
-// Returns an empty slice if GlobalExtensions is empty.
+// Returns an empty slice if GlobalExtensionsToInstall is empty.
+// Invalid extension names (containing spaces or invalid characters) are filtered out.
 func (c *ControllerConfiguration) GetGlobalExtensions() []string {
-	if c.GlobalExtensions == "" {
+	if c.GlobalExtensionsToInstall == "" {
 		return []string{}
 	}
-	extensions := strings.Split(c.GlobalExtensions, ",")
+	extensions := strings.Split(c.GlobalExtensionsToInstall, ",")
 	result := make([]string, 0, len(extensions))
 	for _, ext := range extensions {
 		trimmed := strings.TrimSpace(ext)
-		if trimmed != "" {
+		if trimmed != "" && isValidExtensionName(trimmed) {
 			result = append(result, trimmed)
 		}
 	}
 	return result
+}
+
+// isValidExtensionName validates that an extension name follows PostgreSQL identifier rules.
+// Extension names should contain only letters, digits, underscores, and hyphens.
+// They cannot contain spaces or other special characters.
+func isValidExtensionName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-') {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *ControllerConfiguration) Log(log logr.Logger) {
@@ -106,7 +122,7 @@ func (c *ControllerConfiguration) Log(log logr.Logger) {
 		"hosts", hostNames,
 		"roles", c.UserRoles,
 		"prefix", c.UserRolePrefix,
-		"globalExtensions", c.GlobalExtensions,
+		"globalExtensionsToInstall", c.GlobalExtensionsToInstall,
 		"awsPolicyName", c.AWS.PolicyName,
 		"awsRegion", c.AWS.Region,
 		"awsAccountID", c.AWS.AccountID,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,7 +84,7 @@ func (c *ControllerConfiguration) GetLoginRoles() []string {
 // Returns an empty slice if GlobalExtensions is empty.
 func (c *ControllerConfiguration) GetGlobalExtensions() []string {
 	if c.GlobalExtensions == "" {
-		return []string{}
+		return nil
 	}
 	extensions := strings.Split(c.GlobalExtensions, ",")
 	result := make([]string, 0, len(extensions))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,7 +84,7 @@ func (c *ControllerConfiguration) GetLoginRoles() []string {
 // Returns an empty slice if GlobalExtensions is empty.
 func (c *ControllerConfiguration) GetGlobalExtensions() []string {
 	if c.GlobalExtensions == "" {
-		return nil
+		return []string{}
 	}
 	extensions := strings.Split(c.GlobalExtensions, ",")
 	result := make([]string, 0, len(extensions))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type ControllerConfiguration struct {
 	ResyncPeriod             time.Duration
 	UserRoles                string
 	UserRolePrefix           string
+	GlobalExtensions         string
 	AWS                      AwsConfig
 	HostCredentials          map[string]postgres.Credentials
 	ManagerRoleName          string
@@ -54,6 +55,7 @@ func (c *ControllerConfiguration) RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&c.ManagerRoleName, "manager-role-name", "postgres_role_manager", "Name of the role which will be managing other roles")
 	flagSet.StringVar(&c.SuperuserRoleName, "superuser-role-name", "rds_superuser", "Name of the superuser role the connecting user must be a member of (defaults to RDS's rds_superuser; override for non-RDS deployments)")
 	flagSet.StringVar(&c.UserRoles, "user-roles", "rds_iam", "List of roles granted to all users")
+	flagSet.StringVar(&c.GlobalExtensions, "global-extensions", "", "Comma-separated list of PostgreSQL extensions to install on all databases")
 	flagSet.BoolVar(&c.AllDatabasesReadEnabled, "all-databases-enabled-read", false, "Enable usage of allDatabases field in read access requests")
 	flagSet.BoolVar(&c.AllDatabasesWriteEnabled, "all-databases-enabled-write", false, "Enable usage of allDatabases field in write access requests")
 	flagSet.StringVar(&c.UserRolePrefix, "user-role-prefix", "iam_developer_", "Prefix of roles created in PostgreSQL for users")
@@ -78,6 +80,23 @@ func (c *ControllerConfiguration) GetLoginRoles() []string {
 	return strings.Split(c.AWS.LoginRoles, ",")
 }
 
+// GetGlobalExtensions returns the list of global extensions to install on all databases.
+// Returns an empty slice if GlobalExtensions is empty.
+func (c *ControllerConfiguration) GetGlobalExtensions() []string {
+	if c.GlobalExtensions == "" {
+		return []string{}
+	}
+	extensions := strings.Split(c.GlobalExtensions, ",")
+	result := make([]string, 0, len(extensions))
+	for _, ext := range extensions {
+		trimmed := strings.TrimSpace(ext)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
 func (c *ControllerConfiguration) Log(log logr.Logger) {
 	var hostNames []string
 	for host := range c.HostCredentials {
@@ -87,6 +106,7 @@ func (c *ControllerConfiguration) Log(log logr.Logger) {
 		"hosts", hostNames,
 		"roles", c.UserRoles,
 		"prefix", c.UserRolePrefix,
+		"globalExtensions", c.GlobalExtensions,
 		"awsPolicyName", c.AWS.PolicyName,
 		"awsRegion", c.AWS.Region,
 		"awsAccountID", c.AWS.AccountID,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -187,11 +187,26 @@ func TestControllerConfiguration_GetGlobalExtensions(t *testing.T) {
 			input:  "pgcrypto,,uuid-ossp",
 			output: []string{"pgcrypto", "uuid-ossp"},
 		},
+		{
+			name:   "invalid extension with spaces",
+			input:  "pgcrypto,some thing with spaces,uuid-ossp",
+			output: []string{"pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:   "invalid extension with special characters",
+			input:  "pgcrypto,invalid$ext,uuid-ossp",
+			output: []string{"pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:   "valid extension with underscores and hyphens",
+			input:  "pg_stat_statements,uuid-ossp,my_ext-123",
+			output: []string{"pg_stat_statements", "uuid-ossp", "my_ext-123"},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := ControllerConfiguration{
-				GlobalExtensions: tc.input,
+				GlobalExtensionsToInstall: tc.input,
 			}
 			output := cfg.GetGlobalExtensions()
 			assert.Equal(t, tc.output, output, "parsed extensions not as expected")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,3 +150,51 @@ func TestHostCredentials_String(t *testing.T) {
 		})
 	}
 }
+
+func TestControllerConfiguration_GetGlobalExtensions(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		output []string
+	}{
+		{
+			name:   "empty string",
+			input:  "",
+			output: []string{},
+		},
+		{
+			name:   "single extension",
+			input:  "pgcrypto",
+			output: []string{"pgcrypto"},
+		},
+		{
+			name:   "multiple extensions",
+			input:  "pgcrypto,uuid-ossp,pg_stat_statements",
+			output: []string{"pgcrypto", "uuid-ossp", "pg_stat_statements"},
+		},
+		{
+			name:   "extensions with whitespace",
+			input:  "pgcrypto, uuid-ossp , pg_stat_statements",
+			output: []string{"pgcrypto", "uuid-ossp", "pg_stat_statements"},
+		},
+		{
+			name:   "trailing comma",
+			input:  "pgcrypto,uuid-ossp,",
+			output: []string{"pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:   "empty elements",
+			input:  "pgcrypto,,uuid-ossp",
+			output: []string{"pgcrypto", "uuid-ossp"},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ControllerConfiguration{
+				GlobalExtensions: tc.input,
+			}
+			output := cfg.GetGlobalExtensions()
+			assert.Equal(t, tc.output, output, "parsed extensions not as expected")
+		})
+	}
+}

--- a/internal/controller/postgresqldatabase_controller.go
+++ b/internal/controller/postgresqldatabase_controller.go
@@ -47,6 +47,8 @@ type PostgreSQLDatabaseReconciler struct {
 	SuperuserRoleName string
 	// contains a map of credentials for hosts
 	HostCredentials map[string]postgres.Credentials
+	// GlobalExtensions contains the list of extensions to install on all databases
+	GlobalExtensions []string
 }
 
 //+kubebuilder:rbac:groups=postgresql.lunar.tech,resources=postgresqldatabases,verbs=get;list;watch;create;update;patch;delete
@@ -139,6 +141,9 @@ func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, reqLogger 
 
 	reqLogger.Info("Resolved all referenced values for PostgreSQLDatabase resource")
 
+	// Merge global extensions with database-specific extensions
+	mergedExtensions := r.mergeExtensions(extensions)
+
 	// Ensure the database is in sync with the object
 	err = r.EnsurePostgreSQLDatabase(
 		ctx,
@@ -147,7 +152,7 @@ func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, reqLogger 
 			Host:        host,
 			Admin:       *adminCredentials,
 			ManagerRole: r.ManagerRoleName,
-			Extensions:  fromApiExtensions(extensions),
+			Extensions:  mergedExtensions,
 			Target: postgres.Credentials{
 				Name:     database.Spec.Name,
 				User:     user,
@@ -171,6 +176,31 @@ func fromApiExtensions(extensions []postgresqlv1alpha1.PostgreSQLDatabaseExtensi
 	}
 
 	return postgresExtensions
+}
+
+// mergeExtensions merges global extensions with database-specific extensions, ensuring uniqueness.
+// Database extensions take precedence if there are duplicates.
+func (r *PostgreSQLDatabaseReconciler) mergeExtensions(dbExtensions []postgresqlv1alpha1.PostgreSQLDatabaseExtension) postgres.Extensions {
+	seen := make(map[string]struct{})
+	result := make([]postgres.Extension, 0, len(r.GlobalExtensions)+len(dbExtensions))
+
+	// Add database-specific extensions first
+	for _, ext := range dbExtensions {
+		if _, exists := seen[ext.ExtensionName]; !exists {
+			seen[ext.ExtensionName] = struct{}{}
+			result = append(result, postgres.NewExtension(ext.ExtensionName))
+		}
+	}
+
+	// Add global extensions that aren't already present
+	for _, extName := range r.GlobalExtensions {
+		if _, exists := seen[extName]; !exists {
+			seen[extName] = struct{}{}
+			result = append(result, postgres.NewExtension(extName))
+		}
+	}
+
+	return result
 }
 
 type status struct {

--- a/internal/controller/postgresqldatabase_controller.go
+++ b/internal/controller/postgresqldatabase_controller.go
@@ -168,16 +168,6 @@ func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, reqLogger 
 	return status, nil
 }
 
-func fromApiExtensions(extensions []postgresqlv1alpha1.PostgreSQLDatabaseExtension) postgres.Extensions {
-	postgresExtensions := make([]postgres.Extension, 0, len(extensions))
-
-	for _, e := range extensions {
-		postgresExtensions = append(postgresExtensions, postgres.NewExtension(e.ExtensionName))
-	}
-
-	return postgresExtensions
-}
-
 // mergeExtensions merges global extensions with database-specific extensions, ensuring uniqueness.
 // Database extensions take precedence if there are duplicates.
 func (r *PostgreSQLDatabaseReconciler) mergeExtensions(dbExtensions []postgresqlv1alpha1.PostgreSQLDatabaseExtension) postgres.Extensions {
@@ -239,7 +229,7 @@ func (s *status) update(err error) bool {
 	switch {
 	case err == nil:
 		phase = postgresqlv1alpha1.PostgreSQLDatabasePhaseRunning
-	case err != nil:
+	default:
 		errorMessage = err.Error()
 		if ctlerrors.IsInvalid(err) {
 			phase = postgresqlv1alpha1.PostgreSQLDatabasePhaseInvalid

--- a/internal/controller/postgresqldatabase_controller_extensions_test.go
+++ b/internal/controller/postgresqldatabase_controller_extensions_test.go
@@ -158,6 +158,114 @@ func TestPostgreSQLDatabase_Reconcile_globalExtensions(t *testing.T) {
 	}
 }
 
+// TestPostgreSQLDatabase_Reconcile_extensionsAlreadyInstalled verifies that reconciliation
+// handles already-installed extensions correctly and doesn't fail when extensions exist.
+func TestPostgreSQLDatabase_Reconcile_extensionsAlreadyInstalled(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	host := test.Integration(t)
+	var (
+		epoch        = time.Now().UnixNano()
+		namespace    = "default"
+		databaseName = fmt.Sprintf("database_ext_preinstalled_%d", epoch)
+		managerRole  = "postgres_role_manager"
+	)
+
+	// Create the schema for our tests
+	s := runtime.NewScheme()
+	err := scheme.AddToScheme(s)
+	require.NoError(t, err, "add scheme failed")
+	err = lunarwayv1alpha1.AddToScheme(s)
+	require.NoError(t, err, "add lunar scheme failed")
+
+	// Test case: some extensions are already installed before reconciliation
+	t.Run("some extensions already installed", func(t *testing.T) {
+		dbName := fmt.Sprintf("%s_%d", databaseName, time.Now().UnixNano())
+
+		// Seed the database
+		seededDatabase(t, host, dbName, dbName, managerRole)
+
+		// Pre-install pgcrypto extension before reconciliation
+		conn, err := postgres.Connect(postgres.ConnectionString{
+			Database: dbName,
+			Host:     host,
+			Password: "iam_creator",
+			User:     "iam_creator",
+		})
+		require.NoError(t, err, "failed to connect to database")
+		_, err = conn.Exec(fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA %s", dbName))
+		require.NoError(t, err, "failed to pre-install pgcrypto")
+		conn.Close()
+
+		databaseResource := &lunarwayv1alpha1.PostgreSQLDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dbName,
+				Namespace: namespace,
+			},
+			Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+				Host: lunarwayv1alpha1.ResourceVar{
+					Value: "localhost",
+				},
+				Name: dbName,
+				User: lunarwayv1alpha1.ResourceVar{
+					Value: dbName,
+				},
+				Password: &lunarwayv1alpha1.ResourceVar{
+					Value: "test-password",
+				},
+				Extensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+					{ExtensionName: "pg_trgm"},
+				},
+			},
+		}
+
+		objs := []runtime.Object{databaseResource}
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).WithStatusSubresource(databaseResource).Build()
+
+		hostCredentials := map[string]postgres.Credentials{
+			"localhost": {
+				User:     "iam_creator",
+				Password: "iam_creator",
+			},
+		}
+
+		r := &PostgreSQLDatabaseReconciler{
+			Client:            cl,
+			Log:               ctrl.Log.WithName(t.Name()),
+			HostCredentials:   hostCredentials,
+			ManagerRoleName:   managerRole,
+			SuperuserRoleName: "iam_creator",
+			GlobalExtensions:  []string{"pgcrypto", "uuid-ossp"},
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      dbName,
+				Namespace: namespace,
+			},
+		}
+
+		// Reconcile - should not fail even though pgcrypto is already installed
+		_, err = r.Reconcile(context.Background(), req)
+		require.NoError(t, err, "reconcile should not fail with pre-installed extensions")
+
+		// Verify all extensions are installed
+		conn, err = postgres.Connect(postgres.ConnectionString{
+			Database: dbName,
+			Host:     host,
+			Password: "test-password",
+			User:     dbName,
+		})
+		require.NoError(t, err, "failed to connect to database")
+		defer conn.Close()
+
+		installedExtensions := getInstalledExtensionsFromDB(t, conn)
+		expectedExtensions := []string{"pgcrypto", "uuid-ossp", "pg_trgm"}
+
+		assert.ElementsMatch(t, expectedExtensions, installedExtensions, "all extensions should be installed")
+	})
+}
+
 // getInstalledExtensionsFromDB queries PostgreSQL for installed extensions
 func getInstalledExtensionsFromDB(t *testing.T, conn *sql.DB) []string {
 	t.Helper()

--- a/internal/controller/postgresqldatabase_controller_extensions_test.go
+++ b/internal/controller/postgresqldatabase_controller_extensions_test.go
@@ -1,0 +1,179 @@
+package controller
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lunarwayv1alpha1 "go.lunarway.com/postgresql-controller/api/v1alpha1"
+	"go.lunarway.com/postgresql-controller/pkg/postgres"
+	"go.lunarway.com/postgresql-controller/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// TestPostgreSQLDatabase_Reconcile_globalExtensions verifies that global extensions
+// are merged with database-specific extensions and actually installed on PostgreSQL.
+func TestPostgreSQLDatabase_Reconcile_globalExtensions(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	host := test.Integration(t)
+	var (
+		epoch        = time.Now().UnixNano()
+		namespace    = "default"
+		databaseName = fmt.Sprintf("database_ext_%d", epoch)
+		managerRole  = "postgres_role_manager"
+	)
+
+	// Create the schema for our tests
+	s := runtime.NewScheme()
+	err := scheme.AddToScheme(s)
+	require.NoError(t, err, "add scheme failed")
+	err = lunarwayv1alpha1.AddToScheme(s)
+	require.NoError(t, err, "add lunar scheme failed")
+
+	tests := []struct {
+		name               string
+		globalExtensions   []string
+		databaseExtensions []lunarwayv1alpha1.PostgreSQLDatabaseExtension
+		expectedExtensions []string
+	}{
+		{
+			name:               "only global extensions",
+			globalExtensions:   []string{"pgcrypto", "uuid-ossp"},
+			databaseExtensions: nil,
+			expectedExtensions: []string{"pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:             "only database extensions",
+			globalExtensions: nil,
+			databaseExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pg_trgm"},
+			},
+			expectedExtensions: []string{"pg_trgm"},
+		},
+		{
+			name:             "both global and database extensions",
+			globalExtensions: []string{"pgcrypto", "uuid-ossp"},
+			databaseExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pg_trgm"},
+			},
+			expectedExtensions: []string{"pg_trgm", "pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:             "duplicate extension deduplicated",
+			globalExtensions: []string{"pgcrypto", "uuid-ossp"},
+			databaseExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pgcrypto"},
+			},
+			expectedExtensions: []string{"pgcrypto", "uuid-ossp"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use a unique database name for each test case
+			dbName := fmt.Sprintf("%s_%d", databaseName, time.Now().UnixNano())
+
+			databaseResource := &lunarwayv1alpha1.PostgreSQLDatabase{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dbName,
+					Namespace: namespace,
+				},
+				Spec: lunarwayv1alpha1.PostgreSQLDatabaseSpec{
+					Host: lunarwayv1alpha1.ResourceVar{
+						Value: "localhost",
+					},
+					Name: dbName,
+					User: lunarwayv1alpha1.ResourceVar{
+						Value: dbName,
+					},
+					Password: &lunarwayv1alpha1.ResourceVar{
+						Value: "test-password",
+					},
+					Extensions: tc.databaseExtensions,
+				},
+			}
+
+			objs := []runtime.Object{databaseResource}
+			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).WithStatusSubresource(databaseResource).Build()
+
+			// Create a controller with global extensions configured
+			hostCredentials := map[string]postgres.Credentials{
+				"localhost": {
+					User:     "iam_creator",
+					Password: "iam_creator",
+				},
+			}
+
+			r := &PostgreSQLDatabaseReconciler{
+				Client:            cl,
+				Log:               ctrl.Log.WithName(t.Name()),
+				HostCredentials:   hostCredentials,
+				ManagerRoleName:   managerRole,
+				SuperuserRoleName: "rds_superuser",
+				GlobalExtensions:  tc.globalExtensions,
+			}
+
+			// Seed the database
+			seededDatabase(t, host, dbName, dbName, managerRole)
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      dbName,
+					Namespace: namespace,
+				},
+			}
+
+			// Reconcile to install extensions
+			_, err := r.Reconcile(context.Background(), req)
+			require.NoError(t, err, "reconcile failed")
+
+			// Verify extensions were actually installed
+			conn, err := postgres.Connect(postgres.ConnectionString{
+				Database: dbName,
+				Host:     host,
+				Password: "test-password",
+				User:     dbName,
+			})
+			require.NoError(t, err, "failed to connect to database")
+			defer conn.Close()
+
+			installedExtensions := getInstalledExtensionsFromDB(t, conn)
+
+			// Check that exactly the expected extensions are installed
+			assert.ElementsMatch(t, tc.expectedExtensions, installedExtensions, "installed extensions do not match expected")
+		})
+	}
+}
+
+// getInstalledExtensionsFromDB queries PostgreSQL for installed extensions
+func getInstalledExtensionsFromDB(t *testing.T, conn *sql.DB) []string {
+	t.Helper()
+
+	rows, err := conn.Query("SELECT extname FROM pg_extension WHERE extname != 'plpgsql'")
+	require.NoError(t, err, "failed to query extensions")
+	defer rows.Close()
+
+	var extensions []string
+	for rows.Next() {
+		var extname string
+		err = rows.Scan(&extname)
+		require.NoError(t, err, "failed to scan extension name")
+		extensions = append(extensions, extname)
+	}
+
+	require.NoError(t, rows.Err(), "error iterating rows")
+	return extensions
+}

--- a/internal/controller/postgresqldatabase_controller_extensions_test.go
+++ b/internal/controller/postgresqldatabase_controller_extensions_test.go
@@ -122,7 +122,7 @@ func TestPostgreSQLDatabase_Reconcile_globalExtensions(t *testing.T) {
 				Log:               ctrl.Log.WithName(t.Name()),
 				HostCredentials:   hostCredentials,
 				ManagerRoleName:   managerRole,
-				SuperuserRoleName: "rds_superuser",
+				SuperuserRoleName: "iam_creator",
 				GlobalExtensions:  tc.globalExtensions,
 			}
 

--- a/internal/controller/postgresqldatabase_controller_test.go
+++ b/internal/controller/postgresqldatabase_controller_test.go
@@ -420,3 +420,82 @@ func TestPostgreSQLDatabase_Reconcile_unknownHostCredentialsResourceReference(t 
 		RequeueAfter: 10 * time.Second,
 	}, res, "result not as expected")
 }
+
+func TestPostgreSQLDatabaseReconciler_mergeExtensions(t *testing.T) {
+	tt := []struct {
+		name             string
+		globalExtensions []string
+		dbExtensions     []lunarwayv1alpha1.PostgreSQLDatabaseExtension
+		expected         []string
+	}{
+		{
+			name:             "empty global and empty database",
+			globalExtensions: []string{},
+			dbExtensions:     []lunarwayv1alpha1.PostgreSQLDatabaseExtension{},
+			expected:         nil,
+		},
+		{
+			name:             "nil global and nil database",
+			globalExtensions: nil,
+			dbExtensions:     nil,
+			expected:         nil,
+		},
+		{
+			name:             "only global extensions",
+			globalExtensions: []string{"pgcrypto", "uuid-ossp"},
+			dbExtensions:     []lunarwayv1alpha1.PostgreSQLDatabaseExtension{},
+			expected:         []string{"pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:             "only database extensions",
+			globalExtensions: []string{},
+			dbExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pg_trgm"},
+			},
+			expected: []string{"pg_trgm"},
+		},
+		{
+			name:             "both global and database extensions with no overlap",
+			globalExtensions: []string{"pgcrypto", "uuid-ossp"},
+			dbExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pg_trgm"},
+			},
+			expected: []string{"pg_trgm", "pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:             "duplicate extension in both global and database",
+			globalExtensions: []string{"pgcrypto", "uuid-ossp"},
+			dbExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pgcrypto"},
+			},
+			expected: []string{"pgcrypto", "uuid-ossp"},
+		},
+		{
+			name:             "multiple duplicates",
+			globalExtensions: []string{"pgcrypto", "uuid-ossp", "pg_stat_statements"},
+			dbExtensions: []lunarwayv1alpha1.PostgreSQLDatabaseExtension{
+				{ExtensionName: "pgcrypto"},
+				{ExtensionName: "pg_trgm"},
+				{ExtensionName: "uuid-ossp"},
+			},
+			expected: []string{"pgcrypto", "pg_trgm", "uuid-ossp", "pg_stat_statements"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &PostgreSQLDatabaseReconciler{
+				GlobalExtensions: tc.globalExtensions,
+			}
+
+			result := r.mergeExtensions(tc.dbExtensions)
+
+			var resultNames []string
+			for _, ext := range result {
+				resultNames = append(resultNames, ext.Name)
+			}
+
+			assert.Equal(t, tc.expected, resultNames, "merged extensions not as expected")
+		})
+	}
+}

--- a/internal/controller/postgresqluser_controller.go
+++ b/internal/controller/postgresqluser_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -94,12 +95,7 @@ func (r *PostgreSQLUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func inList(haystack []string, needle string) bool {
-	for _, item := range haystack {
-		if item == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, reqLogger logr.Logger, request reconcile.Request) (ctrl.Result, error) {

--- a/internal/controller/postgresqluser_controller_test.go
+++ b/internal/controller/postgresqluser_controller_test.go
@@ -615,7 +615,7 @@ func assertAccess(t *testing.T, host, databaseName, userName string) {
 func doReconcile(t *testing.T, sut *PostgreSQLUserReconciler, req reconcile.Request) {
 	const reconcileLimit = 10
 
-	for i := 0; i < reconcileLimit; i++ {
+	for range reconcileLimit {
 		res, err := sut.Reconcile(context.Background(), req)
 		assert.NoError(t, err, "reconciliation failed")
 

--- a/pkg/postgres/extensions.go
+++ b/pkg/postgres/extensions.go
@@ -95,7 +95,7 @@ func installExtensions(ctx context.Context, conn *sql.DB, adminCredentials, serv
 			fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", pq.QuoteIdentifier(e.Name), pq.QuoteIdentifier(serviceCredentials.Name)),
 		)
 		if err != nil {
-			return fmt.Errorf("failed to install: user: %s, db: %s, extension %s: %w", adminCredentials.User, serviceCredentials.Name, e.Name, err)
+			return fmt.Errorf("failed to install extension %s, user: %s, db: %s: %w", e.Name, adminCredentials.User, serviceCredentials.Name, err)
 		}
 	}
 

--- a/pkg/postgres/extensions.go
+++ b/pkg/postgres/extensions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/lib/pq"
 	"k8s.io/utils/strings/slices"
 )
 
@@ -91,7 +92,7 @@ func installExtensions(ctx context.Context, conn *sql.DB, adminCredentials, serv
 	for _, e := range extensionsToInstall {
 		_, err := conn.ExecContext(
 			ctx,
-			fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", e.Name, serviceCredentials.Name),
+			fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", pq.QuoteIdentifier(e.Name), pq.QuoteIdentifier(serviceCredentials.Name)),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to install: user: %s, db: %s, extension %s: %w", adminCredentials.User, serviceCredentials.Name, e.Name, err)


### PR DESCRIPTION
## Summary

Add `--global-extensions` flag to postgresql-controller that installs a consistent set of PostgreSQL extensions across all managed databases. Global extensions are merged with per-database extensions into a unique set before installation.

## Why

Follows the pattern of `--user-roles` which applies global roles to all users. Allows operators to enforce a baseline set of extensions (e.g., `pgcrypto`, `uuid-ossp`, `pg_stat_statements`) without modifying every PostgreSQLDatabase CRD.


Closes DMAT-64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reconciliation now installs additional extensions on all managed databases from operator config, which can change production DB state and fail if an extension is unavailable on the server.
> 
> **Overview**
> Adds a **`--global-extensions`** controller flag (comma-separated names, parsed via **`GetGlobalExtensions()`** with trimming) so operators can enforce a baseline set of PostgreSQL extensions on every reconciled database, similar to **`--user-roles`**.
> 
> During **`PostgreSQLDatabase`** reconciliation, per-CRD **`spec.extensions`** are merged with the global list through **`mergeExtensions()`** (database entries first, deduplicated) before **`EnsurePostgreSQLDatabase`** runs. Startup wiring passes the parsed list from **`cmd/main.go`** into the reconciler, and config logging includes the raw flag value.
> 
> Coverage adds unit tests for flag parsing and merge behavior plus integration tests that assert extensions are actually installed on PostgreSQL. Unrelated cleanups use **`slices.Contains`** in the user controller and a **`for range`** loop style in a test helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ce1769b097c6381c260fcf1bad0c0fe37f224f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->