### PR TITLE
fix: grant per-table to avoid lockout on foreign-owned table in service schema

### DIFF
--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -163,7 +163,7 @@ func Database(log logr.Logger, host string, adminCredentials, serviceCredentials
 	}
 
 	// Set default privileges for the service user
-	err = setDefaultPrivileges(serviceConnection, serviceCredentials.User, readRole, readWriteRole, readOwningWriteRole)
+	err = setDefaultPrivileges(log, serviceConnection, serviceCredentials.User, readRole, readWriteRole, readOwningWriteRole)
 	if err != nil {
 		return fmt.Errorf("set default privileges for service user '%s': %w", serviceCredentials.User, err)
 	}
@@ -271,18 +271,18 @@ func grantAdminOption(log logr.Logger, db *sql.DB, serviceRole string, managerRo
 	})
 }
 
-func setDefaultPrivileges(serviceConnection *sql.DB, serviceRole, readRole, readWriteRole, readOwningWriteRole string) error {
-	err := setReadPrivilegesAs(serviceConnection, serviceRole, readRole, serviceRole)
+func setDefaultPrivileges(log logr.Logger, serviceConnection *sql.DB, serviceRole, readRole, readWriteRole, readOwningWriteRole string) error {
+	err := setReadPrivilegesAs(log, serviceConnection, serviceRole, readRole, serviceRole)
 	if err != nil {
 		return fmt.Errorf("set default read privileges for role %s: %w, as %s", readRole, err, serviceRole)
 	}
 
-	err = setReadWritePrivilegesAs(serviceConnection, serviceRole, readWriteRole, serviceRole)
+	err = setReadWritePrivilegesAs(log, serviceConnection, serviceRole, readWriteRole, serviceRole)
 	if err != nil {
 		return fmt.Errorf("set default readwrite privileges for role %s: %w, as %s", readWriteRole, err, serviceRole)
 	}
 
-	err = setReadWritePrivilegesAs(serviceConnection, serviceRole, readOwningWriteRole, serviceRole)
+	err = setReadWritePrivilegesAs(log, serviceConnection, serviceRole, readOwningWriteRole, serviceRole)
 	if err != nil {
 		return fmt.Errorf("set default readowningwrite privileges for role %s: %w, as %s", readOwningWriteRole, err, serviceRole)
 	}
@@ -338,15 +338,15 @@ func tryExec(log logr.Logger, db *sql.DB, args tryExecReq) error {
 	return nil
 }
 
-func setReadPrivilegesAs(db *sql.DB, schema, role, actor string) error {
-	return setDefaultPrivilegesAs(db, schema, role, "SELECT", actor)
+func setReadPrivilegesAs(log logr.Logger, db *sql.DB, schema, role, actor string) error {
+	return setDefaultPrivilegesAs(log, db, schema, role, "SELECT", actor)
 }
 
-func setReadWritePrivilegesAs(db *sql.DB, schema, role, actor string) error {
-	return setDefaultPrivilegesAs(db, schema, role, "SELECT, INSERT, UPDATE, DELETE", actor)
+func setReadWritePrivilegesAs(log logr.Logger, db *sql.DB, schema, role, actor string) error {
+	return setDefaultPrivilegesAs(log, db, schema, role, "SELECT, INSERT, UPDATE, DELETE", actor)
 }
 
-func setDefaultPrivilegesAs(db *sql.DB, schema, role, privileges, actor string) error {
+func setDefaultPrivilegesAs(log logr.Logger, db *sql.DB, schema, role, privileges, actor string) error {
 	// ensures access to future schemas and tables
 	err := execAsf(db, actor, "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT %s ON TABLES TO %s;", schema, privileges, role)
 	if err != nil {
@@ -361,9 +361,41 @@ func setDefaultPrivilegesAs(db *sql.DB, schema, role, privileges, actor string) 
 	if err != nil {
 		return fmt.Errorf("grant %s privileges on existing schema: %w, as %s", privileges, err, actor)
 	}
-	err = execAsf(db, actor, fmt.Sprintf("GRANT %s ON ALL TABLES IN SCHEMA %s TO %s", privileges, schema, role))
+	// Grant per-table rather than with a single GRANT ... ON ALL TABLES IN
+	// SCHEMA. The bulk statement runs as the service user and fails entirely if
+	// the schema contains a table owned by another role, locking developers out
+	// of the service-owned tables they should have access to. Iterating lets us
+	// grant on each table as its owner and tolerate tables we cannot grant on.
+	if err := grantPrivilegesOnExistingTables(log, db, schema, role, privileges); err != nil {
+		return fmt.Errorf("grant %s privileges on existing tables: %w", privileges, err)
+	}
+	return nil
+}
+
+// grantPrivilegesOnExistingTables grants privileges on every table in schema to
+// role, issuing one GRANT per table executed as the table's owner. Tables the
+// owner cannot grant on (insufficient_privilege) are logged and skipped so a
+// foreign-owned table does not block access to the rest of the schema.
+func grantPrivilegesOnExistingTables(log logr.Logger, db *sql.DB, schema, role, privileges string) error {
+	tableOwners, err := tableOwnerMap(db)
 	if err != nil {
-		return fmt.Errorf("grant %s privileges on existing tables: %w, as %s", privileges, err, actor)
+		return fmt.Errorf("look up table owners: %w", err)
+	}
+	for table, owner := range tableOwners[schema] {
+		if err := execWithRole(db, owner, func(tx *sql.Tx) error {
+			_, err := tx.Exec(fmt.Sprintf("GRANT %s ON TABLE %s.%s TO %s",
+				privileges,
+				pq.QuoteIdentifier(schema),
+				pq.QuoteIdentifier(table),
+				pq.QuoteIdentifier(role)))
+			return err
+		}); err != nil {
+			if isPermissionDenied(err) {
+				log.Info("Skipping table grant: permission denied", "schema", schema, "table", table, "owner", owner, "role", role)
+				continue
+			}
+			return fmt.Errorf("grant on %s.%s to %s as %s: %w", schema, table, role, owner, err)
+		}
 	}
 	return nil
 }

--- a/pkg/postgres/database_test.go
+++ b/pkg/postgres/database_test.go
@@ -632,6 +632,128 @@ func TestDatabase_existingResourcePrivilegesForReadWriteRoles(t *testing.T) {
 	dbExec(t, developerDB, fmt.Sprintf(`SELECT * FROM %[1]s.%[1]s`, name))
 }
 
+// TestDatabase_nonServiceOwnedTableInServiceSchema reproduces the lockout
+// scenario where a non-service user owns a table inside the service schema.
+// Reconciliation must still succeed and grant the read role access to the
+// service-owned table rather than failing on the foreign-owned one.
+func TestDatabase_nonServiceOwnedTableInServiceSchema(t *testing.T) {
+	postgresqlHost := test.Integration(t)
+	log := test.SetLogger(t)
+	managerRole := "postgres_role_name"
+	db, err := postgres.Connect(postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: "postgres",
+		User:     "iam_creator",
+		Password: "iam_creator",
+	})
+	if err != nil {
+		t.Fatalf("connect to database failed: %v", err)
+	}
+	defer db.Close()
+
+	err = createManagerRole(log, db, managerRole)
+	if err != nil {
+		t.Fatalf("create manager role failed: %v", err)
+	}
+
+	name := fmt.Sprintf("test_%d", time.Now().UnixNano())
+	developerName := fmt.Sprintf("%s_developer", name)
+	otherUser := fmt.Sprintf("%s_other", name)
+	password := "test"
+
+	// Create the service database and user up front so the service schema
+	// exists and is owned by the service user.
+	log.Info("TC: Run controller database creation")
+	err = postgres.Database(log, postgresqlHost,
+		postgres.Credentials{
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     name,
+			User:     name,
+			Password: password,
+		}, managerRole, nil)
+	if err != nil {
+		t.Fatalf("Create service database failed: %v", err)
+	}
+
+	// Connect as the service user and create a table it owns in the service
+	// schema. The read role must end up with access to this table.
+	serviceDB, err := postgres.Connect(postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: name,
+		User:     name,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("connect as service user failed: %v", err)
+	}
+	defer serviceDB.Close()
+	log.Info("TC: Create service-owned table in service schema")
+	dbExec(t, serviceDB, `CREATE TABLE %[1]s.service_owned (title varchar(40))`, name)
+	dbExec(t, serviceDB, `INSERT INTO %[1]s.service_owned VALUES('service row')`, name)
+
+	// Create a separate non-service user and have it create and own a table in
+	// the service schema. This is the condition that previously broke the bulk
+	// GRANT ... ON ALL TABLES statement and locked users out.
+	log.Info("TC: Create non-service user owning a table in the service schema")
+	dbExec(t, db, `CREATE USER %s WITH PASSWORD '%s' NOCREATEROLE VALID UNTIL 'infinity'`, otherUser, password)
+	dbExec(t, serviceDB, `GRANT CREATE ON SCHEMA %s TO %s`, name, otherUser)
+	otherDB, err := postgres.Connect(postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: name,
+		User:     otherUser,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("connect as non-service user failed: %v", err)
+	}
+	defer otherDB.Close()
+	dbExec(t, otherDB, `CREATE TABLE %[1]s.foreign_owned (title varchar(40))`, name)
+
+	// Reconcile again. With a foreign-owned table present in the schema this
+	// must still succeed.
+	log.Info("TC: Re-run controller database creation with foreign-owned table present")
+	err = postgres.Database(log, postgresqlHost,
+		postgres.Credentials{
+			User:     "iam_creator",
+			Password: "iam_creator",
+		}, postgres.Credentials{
+			Name:     name,
+			User:     name,
+			Password: password,
+		}, managerRole, nil)
+	if err != nil {
+		t.Fatalf("reconcile with foreign-owned table failed: %v", err)
+	}
+
+	// Grant a developer read access and verify it can read the service-owned
+	// table despite the foreign-owned table in the same schema.
+	log.Info("TC: Run controller user creation")
+	err = postgres.Role(log, db, developerName, nil, []postgres.DatabaseSchema{{
+		Name:       name,
+		Schema:     name,
+		Privileges: postgres.PrivilegeRead,
+	}})
+	if err != nil {
+		t.Fatalf("create developer role failed: %v", err)
+	}
+
+	developerDB, err := postgres.Connect(postgres.ConnectionString{
+		Host:     postgresqlHost,
+		Database: name,
+		User:     developerName,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("connect as developer failed: %v", err)
+	}
+	defer developerDB.Close()
+	log.Info("TC: Developer selects from service-owned table")
+	rows := dbQuery(t, developerDB, `SELECT * FROM %s.service_owned`, name)
+	assert.Equal(t, []string{"service row"}, rows, "service-owned rows not as expected")
+}
+
 // TestDatabase_defaultDatabaseName tests that we can handle database resources
 // referencing the default name of the database instance.
 func TestDatabase_defaultDatabaseName(t *testing.T) {


### PR DESCRIPTION
## Summary

`Database()` reconciliation failed — and locked developers out — when a non-service user owned one or more tables in the service schema. The bulk `GRANT <privileges> ON ALL TABLES IN SCHEMA <schema> TO <role>` statement in `setDefaultPrivilegesAs` ran as the service user and aborted the entire reconciliation on the first foreign-owned table (`permission denied for table ...`), so the read/write roles never received access to the service-owned tables they should have.

## Changes

- `pkg/postgres/database.go`: replace the bulk `GRANT ... ON ALL TABLES IN SCHEMA` with a new `grantPrivilegesOnExistingTables` helper that iterates `tableOwnerMap(db)[schema]` and issues one `GRANT ... ON TABLE <schema>.<table> TO <role>` per table via `execWithRole(db, owner, …)` — running each grant as the table's owner. Tables the owner cannot grant on (`insufficient_privilege`, SQLSTATE 42501) are logged and skipped, mirroring `SyncDatabaseGrants`.
- Threaded `logr.Logger` through `setDefaultPrivileges` → `setRead*PrivilegesAs` → `setDefaultPrivilegesAs` to support the skip logging.
- `pkg/postgres/database_test.go`: new integration test `TestDatabase_nonServiceOwnedTableInServiceSchema` reproducing the lockout.


## Why

The setup connection authenticates as a superuser-level role and only `SET ROLE`s down, so `execWithRole`'s `SET LOCAL ROLE owner` succeeds for any owner. Granting per-table as each table's owner means the service-owned tables are always granted regardless of foreign-owned tables present in the same schema.

Closes DMAT-405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core privilege reconciliation during database setup; behavior is safer for mixed ownership but skipped grants on some tables could leave gaps if misconfigured.
> 
> **Overview**
> Fixes **`Database()` reconciliation failing** when a non-service role owns a table in the service schema. The bulk `GRANT ... ON ALL TABLES IN SCHEMA` ran as the service user and **aborted the whole step** on the first foreign-owned table, so read/readwrite roles never got grants on service-owned tables.
> 
> **`setDefaultPrivilegesAs`** now calls **`grantPrivilegesOnExistingTables`**, which walks tables from **`tableOwnerMap`**, runs each `GRANT ... ON TABLE` via **`execWithRole`** as that table’s owner, and **logs and skips** tables that return insufficient privilege (same pattern as **`SyncDatabaseGrants`**). A **`logr.Logger`** is threaded through **`setDefaultPrivileges`** and the read/readwrite helpers for skip logging.
> 
> Adds integration test **`TestDatabase_nonServiceOwnedTableInServiceSchema`** to assert reconcile succeeds and developers can read service-owned tables when a foreign-owned table exists in the same schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78bfffa83d0dbbc272c088f0bf6658dff1f52c2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->