### PR TITLE
Install extensions in the service's own schema

### DIFF
--- a/pkg/postgres/extensions.go
+++ b/pkg/postgres/extensions.go
@@ -89,9 +89,13 @@ func extensionsToInstall(extensions, alreadyAvailableExtensions Extensions) (Ext
 // installExtensions actually enable extensions on the database
 func installExtensions(ctx context.Context, conn *sql.DB, adminCredentials, serviceCredentials Credentials, extensionsToInstall []Extension) error {
 	for _, e := range extensionsToInstall {
+		// Extensions are installed into the schema of the service, ie. the one
+		// named after the service user, and never the schema of another service on
+		// the same database. For shared databases the database name is the name of
+		// another service's schema.
 		_, err := conn.ExecContext(
 			ctx,
-			fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", e.Name, serviceCredentials.Name),
+			fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", e.Name, serviceCredentials.User),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to install: user: %s, db: %s, extension %s: %w", adminCredentials.User, serviceCredentials.Name, e.Name, err)


### PR DESCRIPTION
## Problem

`installExtensions` created extensions with `WITH SCHEMA <serviceCredentials.Name>`, i.e. the *database* name. For shared databases the database name is the name of another service's schema, so extensions could be installed into a schema belonging to a different service. In almost all cases, this changes nothing as normally only one service uses a single database.

## Change

Use `serviceCredentials.User` instead — the schema named after the service user, which the service actually owns.

## Notes

- For non-shared databases name and user typically match, so behaviour is unchanged there.
- Existing extensions already created in the wrong schema are not moved by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where new extensions are created on shared databases; existing mis-placed extensions are not migrated, so behaviour only affects new installs.
> 
> **Overview**
> **`installExtensions`** now runs `CREATE EXTENSION ... WITH SCHEMA` using **`serviceCredentials.User`** instead of **`serviceCredentials.Name`**, so extensions land in the schema owned by the service user.
> 
> On **shared databases**, the database name can match another service’s schema, which previously caused extensions to be created in the wrong schema. Dedicated databases where name and user match are unchanged.
> 
> This does **not** relocate extensions already created in the wrong schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ee40a25fa3c498bd20ab7574d8631a8a6fa155. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->